### PR TITLE
feat: embed user data in membership list endpoint (closes #4)

### DIFF
--- a/backend/app/api/routes/memberships.py
+++ b/backend/app/api/routes/memberships.py
@@ -115,7 +115,11 @@ def list_memberships(
     if status_filter:
         query = query.filter(Membership.status == status_filter)
 
-    return [_serialize(m, include_user=True) for m in query.order_by(Membership.id).all()]
+    # Return ORM objects directly — Pydantic serializes via from_attributes=True,
+    # which correctly handles the nested user relationship. _serialize() returns a
+    # plain dict which breaks nested ORM object serialization (FastAPI cannot apply
+    # from_attributes inside a dict), so the list endpoint bypasses it entirely.
+    return query.order_by(Membership.id).all()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
`GET /tournaments/{id}/memberships/` now returns user info (name, email, role) inline on each membership, eliminating the O(n) per-membership user fetches that were causing rate limiting on the volunteers page.

## Changes
**`backend/app/api/routes/memberships.py`**
- Added `joinedload(Membership.user)` to the list query — SQLAlchemy fetches all users in a single JOIN instead of lazy-loading per row
- Switched `GET /` `response_model` from `MembershipRead` to `MembershipReadWithUser` (schema already existed, just wasn't wired up)
- List endpoint now returns ORM objects directly so Pydantic can serialize the nested `user` relationship via `from_attributes` — returning a plain `dict` broke nested ORM serialization
- All other endpoints (get, create, update, delete) are unchanged

## Testing
- Verified locally on dev env — volunteers page loads correctly with user data inline
- No DB migration needed (no schema changes)