### PR TITLE
refactor/sheet config remove option raw and alias

### DIFF
--- a/backend/alembic/versions/f6a7b8c9d0e1_normalize_column_mappings_options_to_strings.py
+++ b/backend/alembic/versions/f6a7b8c9d0e1_normalize_column_mappings_options_to_strings.py
@@ -1,23 +1,31 @@
 """normalize column_mappings options to list[str]
 
 Revision ID: f6a7b8c9d0e1
-Revises: e975e198a8e1
+Revises: ffc1c5a0d62f
 Create Date: 2026-04-02
 
-Data migration: ColumnMapping.options was previously stored as
-list[{raw, alias}] objects. It is now list[str] (raw strings only),
-with aliases encoded as is_alias=True rules on the mapping.
+Data migration for sheet_configs.column_mappings:
 
-This migration flattens any {raw, alias} objects in options to just
-the raw string. Entries that are already strings are left as-is.
+1. Shape normalisation — legacy dict shape {header: {field, type, ...}} is
+   converted to the canonical list shape [{column_index, header, ...}],
+   assigning column_index by iteration order.
 
-Downgrade is a no-op — alias information cannot be reconstructed
-from raw strings alone without the corresponding rules.
+2. Options normalisation — options stored as [{raw, alias}] objects are
+   flattened to plain raw strings. Entries already stored as strings are
+   left as-is.
+
+3. is_alias tagging — for each rule with condition="contains" and
+   action="replace", if rule.match equals one of the raw option strings
+   then is_alias=True is set (the rule was generated from an alias).
+   Rules whose match does not appear in the options list are left as-is
+   (is_alias is not added / stays False).
+
+Downgrade is a no-op.
 """
 from __future__ import annotations
 
 import json
-from typing import Sequence, Union
+from typing import Any, Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
@@ -29,9 +37,33 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
-def _normalize_options(options: list) -> tuple[list, bool]:
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _normalize_shape(column_mappings: Any) -> tuple[list[dict], bool]:
     """
-    Flatten any {raw, alias} dicts in options to plain raw strings.
+    Convert legacy dict shape to canonical list shape.
+    Returns (list_of_entries, changed).
+    """
+    if isinstance(column_mappings, dict):
+        entries = []
+        for idx, (header, mapping) in enumerate(column_mappings.items()):
+            entry = dict(mapping) if isinstance(mapping, dict) else {}
+            entry.setdefault("column_index", idx)
+            entry["header"] = header
+            entries.append(entry)
+        return entries, True
+
+    if isinstance(column_mappings, list):
+        return column_mappings, False
+
+    return [], True
+
+
+def _normalize_options(options: list) -> tuple[list[str], bool]:
+    """
+    Flatten [{raw, alias}] dicts to plain raw strings.
     Returns (normalized_list, changed).
     """
     result = []
@@ -44,6 +76,30 @@ def _normalize_options(options: list) -> tuple[list, bool]:
             result.append(o)
     return result, changed
 
+
+def _tag_alias_rules(rules: list[dict], raw_options: set[str]) -> tuple[list[dict], bool]:
+    """
+    Set is_alias=True on rules whose match value appears in raw_options.
+    Returns (updated_rules, changed).
+    """
+    changed = False
+    result = []
+    for rule in rules:
+        if (
+            rule.get("condition") == "contains"
+            and rule.get("action") == "replace"
+            and rule.get("match") in raw_options
+        ):
+            if not rule.get("is_alias"):
+                rule = {**rule, "is_alias": True}
+                changed = True
+        result.append(rule)
+    return result, changed
+
+
+# ---------------------------------------------------------------------------
+# Migration
+# ---------------------------------------------------------------------------
 
 def upgrade() -> None:
     bind = op.get_bind()
@@ -60,31 +116,45 @@ def upgrade() -> None:
         if raw is None:
             continue
 
-        # SQLite returns JSON columns as strings; PostgreSQL returns native objects.
+        # SQLite returns JSON columns as strings; PostgreSQL as native objects.
         mappings = json.loads(raw) if isinstance(raw, str) else raw
-        if not isinstance(mappings, list):
-            continue
 
-        changed = False
-        for entry in mappings:
+        # 1. Normalise shape (dict → list)
+        entries, shape_changed = _normalize_shape(mappings)
+
+        # 2 & 3. Normalise options and tag alias rules per entry
+        data_changed = False
+        for entry in entries:
             if not isinstance(entry, dict):
                 continue
-            options = entry.get("options")
-            if not options or not isinstance(options, list):
-                continue
-            normalized, entry_changed = _normalize_options(options)
-            if entry_changed:
-                entry["options"] = normalized
-                changed = True
 
-        if not changed:
+            options = entry.get("options")
+            raw_set: set[str] = set()
+
+            if options and isinstance(options, list):
+                normalized, opts_changed = _normalize_options(options)
+                if opts_changed:
+                    entry["options"] = normalized
+                    data_changed = True
+                raw_set = {o for o in normalized if isinstance(o, str)}
+
+            rules = entry.get("rules")
+            if rules and isinstance(rules, list) and raw_set:
+                tagged, rules_changed = _tag_alias_rules(rules, raw_set)
+                if rules_changed:
+                    entry["rules"] = tagged
+                    data_changed = True
+
+        if not shape_changed and not data_changed:
             continue
 
-        serialized = json.dumps(mappings)
+        serialized = json.dumps(entries)
         if dialect == "postgresql":
             bind.execute(
                 sa.text(
-                    "UPDATE sheet_configs SET column_mappings = cast(:cm AS jsonb) WHERE id = :id"
+                    "UPDATE sheet_configs"
+                    " SET column_mappings = cast(:cm AS jsonb)"
+                    " WHERE id = :id"
                 ),
                 {"cm": serialized, "id": config_id},
             )
@@ -98,5 +168,5 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Cannot reconstruct {raw, alias} pairs from raw strings alone.
+    # Shape and field changes cannot be reliably reversed.
     pass

--- a/backend/alembic/versions/f6a7b8c9d0e1_normalize_column_mappings_options_to_strings.py
+++ b/backend/alembic/versions/f6a7b8c9d0e1_normalize_column_mappings_options_to_strings.py
@@ -24,7 +24,7 @@ import sqlalchemy as sa
 
 
 revision: str = 'f6a7b8c9d0e1'
-down_revision: Union[str, None] = 'e975e198a8e1'
+down_revision: Union[str, None] = 'ffc1c5a0d62f'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/alembic/versions/f6a7b8c9d0e1_normalize_column_mappings_options_to_strings.py
+++ b/backend/alembic/versions/f6a7b8c9d0e1_normalize_column_mappings_options_to_strings.py
@@ -1,0 +1,102 @@
+"""normalize column_mappings options to list[str]
+
+Revision ID: f6a7b8c9d0e1
+Revises: e975e198a8e1
+Create Date: 2026-04-02
+
+Data migration: ColumnMapping.options was previously stored as
+list[{raw, alias}] objects. It is now list[str] (raw strings only),
+with aliases encoded as is_alias=True rules on the mapping.
+
+This migration flattens any {raw, alias} objects in options to just
+the raw string. Entries that are already strings are left as-is.
+
+Downgrade is a no-op — alias information cannot be reconstructed
+from raw strings alone without the corresponding rules.
+"""
+from __future__ import annotations
+
+import json
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'f6a7b8c9d0e1'
+down_revision: Union[str, None] = 'e975e198a8e1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _normalize_options(options: list) -> tuple[list, bool]:
+    """
+    Flatten any {raw, alias} dicts in options to plain raw strings.
+    Returns (normalized_list, changed).
+    """
+    result = []
+    changed = False
+    for o in options:
+        if isinstance(o, dict) and "raw" in o:
+            result.append(o["raw"])
+            changed = True
+        else:
+            result.append(o)
+    return result, changed
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name  # "sqlite" or "postgresql"
+
+    rows = bind.execute(
+        sa.text("SELECT id, column_mappings FROM sheet_configs")
+    ).fetchall()
+
+    for row in rows:
+        config_id: int = row[0]
+        raw = row[1]
+
+        if raw is None:
+            continue
+
+        # SQLite returns JSON columns as strings; PostgreSQL returns native objects.
+        mappings = json.loads(raw) if isinstance(raw, str) else raw
+        if not isinstance(mappings, list):
+            continue
+
+        changed = False
+        for entry in mappings:
+            if not isinstance(entry, dict):
+                continue
+            options = entry.get("options")
+            if not options or not isinstance(options, list):
+                continue
+            normalized, entry_changed = _normalize_options(options)
+            if entry_changed:
+                entry["options"] = normalized
+                changed = True
+
+        if not changed:
+            continue
+
+        serialized = json.dumps(mappings)
+        if dialect == "postgresql":
+            bind.execute(
+                sa.text(
+                    "UPDATE sheet_configs SET column_mappings = cast(:cm AS jsonb) WHERE id = :id"
+                ),
+                {"cm": serialized, "id": config_id},
+            )
+        else:
+            bind.execute(
+                sa.text(
+                    "UPDATE sheet_configs SET column_mappings = :cm WHERE id = :id"
+                ),
+                {"cm": serialized, "id": config_id},
+            )
+
+
+def downgrade() -> None:
+    # Cannot reconstruct {raw, alias} pairs from raw strings alone.
+    pass

--- a/backend/app/schemas/sheet_config.py
+++ b/backend/app/schemas/sheet_config.py
@@ -140,10 +140,14 @@ class ParseRule(BaseModel):
     case_sensitive: bool = False
     action: str
     value: str | None = None
+    is_alias: bool = False  # True = generated from a form option alias
 
     def model_dump(self, **kwargs):
         kwargs.setdefault("exclude_none", True)
-        return super().model_dump(**kwargs)
+        result = super().model_dump(**kwargs)
+        if not result.get("is_alias", False):
+            result.pop("is_alias", None)
+        return result
 
     @field_validator("condition")
     @classmethod
@@ -201,7 +205,8 @@ class ColumnMapping(BaseModel):
     delimiter: str | None = None
 
     # Form question enrichment — persisted so edit page + exports retain alias editor context
-    options:      list[FormQuestionOption] | None = None
+    # options is a flat list of raw option strings; aliases are encoded in rules (is_alias=True)
+    options:      list[str] | None = None
     grid_rows:    list[str] | None = None
     grid_columns: list[str] | None = None
 

--- a/backend/app/services/sheets_service.py
+++ b/backend/app/services/sheets_service.py
@@ -263,6 +263,7 @@ def _alias_rules(options: list) -> list[ParseRule]:
                 case_sensitive=False,
                 action="replace",
                 value=alias,
+                is_alias=True,
             ))
     return rules
 

--- a/backend/app/services/sync_service.py
+++ b/backend/app/services/sync_service.py
@@ -421,8 +421,16 @@ def _process_cell(
             # Option-aware splitting: greedily match known options so commas
             # inside option text (e.g. "Life, Personal & Social Science") are
             # not treated as delimiters.
+            # options is list[str] (raw); derive aliases from is_alias rules so
+            # post-rules transformed values are matched correctly.
+            rules_list = mapping.get("rules") or []
+            alias_map = {
+                r["match"]: r["value"]
+                for r in rules_list
+                if r.get("is_alias") and r.get("match") and r.get("value")
+            }
             alias_options = sorted(
-                [o["alias"] if isinstance(o, dict) else o.alias for o in options],
+                [alias_map.get(o, o) for o in options],
                 key=len,
                 reverse=True,
             )

--- a/frontend/app/dashboard/[tournamentId]/sheets/[configId]/edit/page.tsx
+++ b/frontend/app/dashboard/[tournamentId]/sheets/[configId]/edit/page.tsx
@@ -298,6 +298,25 @@ export default function EditSheetPage() {
       const { updatedRows, summary } = applyImport(activeRows, parsed);
       const { updated: updatedList, unchanged, notInSheet, notInFile } = summary;
 
+      // Carry options from the imported file into headerOptions state so the
+      // alias editor displays correctly and options are persisted on save.
+      const importedOptionsMap = new Map<number, string[]>();
+      for (const m of parsed.column_mappings) {
+        if (m.options && m.options.length > 0) {
+          importedOptionsMap.set(m.column_index, m.options as string[]);
+        }
+      }
+      if (importedOptionsMap.size > 0) {
+        setHeaderOptions((prev) => {
+          const next = new Map(prev);
+          for (const [idx, options] of importedOptionsMap) {
+            const existing = next.get(idx) ?? {};
+            next.set(idx, { ...existing, options });
+          }
+          return next;
+        });
+      }
+
       setMappingRows((prev) =>
         prev.map((r) => {
           if (r.state === "removed") return r;
@@ -307,9 +326,10 @@ export default function EditSheetPage() {
           const hadRuleChanges = updatedList.some(
             (entry) => entry.column_index === r.column_index && entry.ruleDiffs.some((d) => d.status !== "unchanged")
           );
+          const options = importedOptionsMap.get(r.column_index) ?? r.options;
           const base = r.state === "new"
-            ? { ...r, ...updated, importedValue }
-            : makeRichRow(updated, r.baseline, undefined, importedValue, undefined, r.options);
+            ? { ...r, ...updated, importedValue, options }
+            : makeRichRow(updated, r.baseline, undefined, importedValue, undefined, options);
           return { ...base, openOnMount: hadRuleChanges || undefined };
         })
       );

--- a/frontend/app/dashboard/[tournamentId]/sheets/[configId]/edit/page.tsx
+++ b/frontend/app/dashboard/[tournamentId]/sheets/[configId]/edit/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useRef, useCallback } from "react";
 import { useRouter, useParams } from "next/navigation";
-import { sheetsApi, ColumnMapping, ColumnMappingEntry, SheetConfig, SheetType, MappedHeader, FormQuestionOption } from "@/lib/api";
+import { sheetsApi, ColumnMapping, ColumnMappingEntry, SheetConfig, SheetType, MappedHeader } from "@/lib/api";
 import {
   MappingRow,
   MappingsExport,
@@ -65,8 +65,9 @@ function emptyMappingRow(header: string, s?: Partial<ColumnMappingEntry>): Mappi
 function resolveOptions(
   liveMapping?: MappedHeader,
   savedMapping?: ColumnMapping,
-): FormQuestionOption[] | undefined {
-  return liveMapping?.options ?? savedMapping?.options ?? undefined;
+): string[] | undefined {
+  if (liveMapping?.options) return liveMapping.options.map((o) => o.raw);
+  return savedMapping?.options ?? undefined;
 }
 
 // ─── Main Page ────────────────────────────────────────────────────────────────
@@ -95,7 +96,7 @@ export default function EditSheetPage() {
   const [headersError,    setHeadersError]    = useState("");
 
   // Track options per column index for buildColumnMappings persistence
-  const [headerOptions, setHeaderOptions] = useState<Map<number, { options?: FormQuestionOption[]; grid_rows?: string[]; grid_columns?: string[] }>>(new Map());
+  const [headerOptions, setHeaderOptions] = useState<Map<number, { options?: string[]; grid_rows?: string[]; grid_columns?: string[] }>>(new Map());
 
   // Load state
   const [loading,   setLoading]   = useState(true);
@@ -179,7 +180,7 @@ export default function EditSheetPage() {
       );
       const liveIndices  = new Set(result.mappings.map((m: MappedHeader) => m.column_index));
       const rows: RichMappingRow[] = [];
-      const optionsMap = new Map<number, { options?: FormQuestionOption[]; grid_rows?: string[]; grid_columns?: string[] }>();
+      const optionsMap = new Map<number, { options?: string[]; grid_rows?: string[]; grid_columns?: string[] }>();
 
       for (const m of result.mappings) {
         const saved = savedByIndex.get(m.column_index);

--- a/frontend/app/dashboard/[tournamentId]/sheets/new/page.tsx
+++ b/frontend/app/dashboard/[tournamentId]/sheets/new/page.tsx
@@ -325,6 +325,25 @@ export default function NewSheetPage() {
       const { updatedRows, summary } = applyImport(plainRows, parsed);
       const { updated: updatedList, unchanged, notInSheet, notInFile } = summary;
 
+      // Carry options from the imported file into headerOptions state so the
+      // alias editor displays correctly and options are persisted on save.
+      const importedOptionsMap = new Map<number, string[]>();
+      for (const m of parsed.column_mappings) {
+        if (m.options && m.options.length > 0) {
+          importedOptionsMap.set(m.column_index, m.options as string[]);
+        }
+      }
+      if (importedOptionsMap.size > 0) {
+        setHeaderOptions((prev) => {
+          const next = new Map(prev);
+          for (const [idx, options] of importedOptionsMap) {
+            const existing = next.get(idx) ?? {};
+            next.set(idx, { ...existing, options });
+          }
+          return next;
+        });
+      }
+
       setMappingRows((prev) =>
         prev.map((r) => {
           const updated = updatedRows.find((u) => u.column_index === r.column_index);
@@ -333,7 +352,8 @@ export default function NewSheetPage() {
           const hadRuleChanges = updatedList.some(
             (entry) => entry.column_index === r.column_index && entry.ruleDiffs.some((d) => d.status !== "unchanged")
           );
-          const base = makeRichRow(updated, r.baseline, undefined, importedValue, undefined, r.options);
+          const options = importedOptionsMap.get(r.column_index) ?? r.options;
+          const base = makeRichRow(updated, r.baseline, undefined, importedValue, undefined, options);
           return { ...base, openOnMount: hadRuleChanges || undefined };
         })
       );

--- a/frontend/app/dashboard/[tournamentId]/sheets/new/page.tsx
+++ b/frontend/app/dashboard/[tournamentId]/sheets/new/page.tsx
@@ -171,7 +171,7 @@ export default function NewSheetPage() {
   const importInputRef = useRef<HTMLInputElement>(null);
 
   // Track options per column index so duplicate headers stay distinct
-  const [headerOptions, setHeaderOptions] = useState<Map<number, { options?: import("@/lib/api").FormQuestionOption[]; grid_rows?: string[]; grid_columns?: string[] }>>(new Map());
+  const [headerOptions, setHeaderOptions] = useState<Map<number, { options?: string[]; grid_rows?: string[]; grid_columns?: string[] }>>(new Map());
 
   // Validation
   const {
@@ -248,14 +248,15 @@ export default function NewSheetPage() {
       setHeadersResult(result);
 
       // Track options per header for buildColumnMappings persistence
-      const optionsMap = new Map<number, { options?: import("@/lib/api").FormQuestionOption[]; grid_rows?: string[]; grid_columns?: string[] }>();
+      const optionsMap = new Map<number, { options?: string[]; grid_rows?: string[]; grid_columns?: string[] }>();
 
       const rows: RichMappingRow[] = result.mappings.map((m: MappedHeader) => {
         const base = emptyMappingRow(m.header, m);
-        if (m.options || m.grid_rows || m.grid_columns) {
-          optionsMap.set(m.column_index, { options: m.options, grid_rows: m.grid_rows, grid_columns: m.grid_columns });
+        const rawOptions = m.options?.map((o) => o.raw);
+        if (rawOptions || m.grid_rows || m.grid_columns) {
+          optionsMap.set(m.column_index, { options: rawOptions, grid_rows: m.grid_rows, grid_columns: m.grid_columns });
         }
-        return makeRichRow(base, base, undefined, undefined, undefined, m.options ?? undefined);
+        return makeRichRow(base, base, undefined, undefined, undefined, rawOptions);
       });
 
       setHeaderOptions(optionsMap);

--- a/frontend/components/ui/SheetConfigMappingTable.tsx
+++ b/frontend/components/ui/SheetConfigMappingTable.tsx
@@ -79,8 +79,8 @@ export interface RichMappingRow extends MappingRow {
   openOnMount?:   boolean;
   /** Increments when new validation results arrive — opens accordion if this row has rule-level issues. */
   validationGeneration?: number;
-  /** Form answer options — present when the backend matched a form question with choices. */
-  options?: FormQuestionOption[];
+  /** Raw form answer option strings — present when the backend matched a form question with choices. */
+  options?: string[];
   /** Whether the alias editor (true) or rules editor (false) is shown. Stored in parent state
    *  so it survives remounts caused by rule changes. Defaults to true when options present. */
   showAliasEditor?: boolean;
@@ -121,29 +121,24 @@ function aliasesToRules(options: FormQuestionOption[]): ParseRule[] {
       case_sensitive: false,
       action:         "replace",
       value:          o.alias,
+      is_alias:       true,
     }));
 }
 
 function rulesAndOptionsToAliases(
   rules: ParseRule[],
-  options: FormQuestionOption[],
+  options: string[],
 ): FormQuestionOption[] {
-  return options.map((opt) => {
-    const rule = rules.find(
-      (r) => r.condition === "contains" && r.match === opt.raw && r.action === "replace"
-    );
-    return rule ? { ...opt, alias: rule.value ?? opt.alias } : opt;
+  return options.map((raw) => {
+    const rule = rules.find((r) => r.is_alias && r.match === raw && r.action === "replace");
+    return { raw, alias: rule?.value ?? raw };
   });
 }
 
 // ─── Alias Editor ─────────────────────────────────────────────────────────────
 
-function isAliasRule(rule: ParseRule, options: FormQuestionOption[]): boolean {
-  return (
-    rule.condition === "contains" &&
-    rule.action    === "replace"  &&
-    options.some((o) => o.raw === rule.match)
-  );
+function isAliasRule(rule: ParseRule): boolean {
+  return rule.is_alias === true;
 }
 
 const AliasEditor = memo(function AliasEditor({
@@ -158,7 +153,7 @@ const AliasEditor = memo(function AliasEditor({
   rowErrors,
   rowWarnings,
 }: {
-  options:         FormQuestionOption[];
+  options:         string[];
   currentRules:    ParseRule[];
   onChangeRules:   (rules: ParseRule[]) => void;
   isRemoved:       boolean;
@@ -184,7 +179,7 @@ const AliasEditor = memo(function AliasEditor({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentRules]);
 
-  const extraRules = currentRules.filter((r) => !isAliasRule(r, options));
+  const extraRules = currentRules.filter((r) => !isAliasRule(r));
 
   function handleAliasChange(idx: number, value: string) {
     const next = aliases.map((a, i) => i === idx ? { ...a, alias: value } : a);
@@ -850,7 +845,7 @@ const MappingRowComponent = memo(function MappingRowComponent({
   const hasRuleWarnings = !hasRuleErrors && warnings.some((w) => w.rule_index != null);
 
   const extraRuleCount = hasAliasEditor
-    ? row.rules.filter((r) => !isAliasRule(r, row.options ?? [])).length
+    ? row.rules.filter((r) => !isAliasRule(r)).length
     : 0;
 
   const accordionLabel = hasAliasEditor
@@ -1247,7 +1242,7 @@ export function makeRichRow(
   values: MappingRow, baseline: MappingRow,
   forcedState?: "new" | "removed", importedValue?: MappingRow,
   openOnMount?: boolean,
-  options?: FormQuestionOption[],
+  options?: string[],
 ): RichMappingRow {
   let state: RowState = forcedState ?? "same";
   if (!forcedState) state = mappingRowsEqual(values, baseline) ? "same" : "changed";

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -286,6 +286,7 @@ export interface ParseRule {
   case_sensitive: boolean
   action:         ParseRuleAction
   value?:         string
+  is_alias?:      boolean
 }
 
 export interface ColumnMapping {
@@ -296,7 +297,8 @@ export interface ColumnMapping {
   rules?:        ParseRule[]
   delimiter?:    string
   // Persisted form enrichment — powers alias editor on edit page + JSON exports
-  options?:      FormQuestionOption[]
+  // options is a flat list of raw option strings; aliases are encoded in rules (is_alias=true)
+  options?:      string[]
   grid_rows?:    string[]
   grid_columns?: string[]
 }


### PR DESCRIPTION
Closes #19 

## Summary

- Add `is_alias: bool` to `ParseRule` (backend + frontend) so alias rules generated from form option pairs are explicitly tagged, replacing fragile options-list matching
- Change `ColumnMapping.options` from `list[FormQuestionOption]` to `list[str]` (raw option strings only) — aliases are now derived from `is_alias` rules at runtime, eliminating a second source of truth that could drift
- Add an Alembic data migration that normalises existing `sheet_configs.column_mappings` rows: converts legacy dict shape to list, flattens `{raw, alias}` option objects to plain strings, and tags matching rules with `is_alias=True`

## Changes

**Backend**
- `schemas/sheet_config.py` — `ParseRule` gains `is_alias: bool = False`; excluded from serialised JSON when `False` so existing saved rules are unaffected. `ColumnMapping.options` changed to `list[str] | None`; `MappedHeader.options` stays `list[FormQuestionOption] | None` (wizard response only)
- `services/sheets_service.py` — `_alias_rules()` sets `is_alias=True` on generated rules
- `services/sync_service.py` — `_process_cell` builds alias options by mapping raw strings through `is_alias` rules instead of extracting `.alias` from stored option objects

**Frontend**
- `lib/api.ts` — `ParseRule` gains `is_alias?: boolean`; `ColumnMapping.options` changed to `string[]`; `MappedHeader.options` stays `FormQuestionOption[]`
- `components/ui/SheetConfigMappingTable.tsx` — `isAliasRule()` is now `rule.is_alias === true`; `aliasesToRules()` sets `is_alias: true`; `rulesAndOptionsToAliases()` takes `string[]` and reconstructs display pairs via `is_alias` rules; `RichMappingRow.options` and `makeRichRow` param typed as `string[]`
- `app/.../sheets/new/page.tsx` — `headerOptions` typed as `string[]`; raw strings extracted from `MappedHeader.options` before storing
- `app/.../sheets/[configId]/edit/page.tsx` — `resolveOptions()` returns `string[]`; live `MappedHeader.options` mapped to `.raw` strings; `headerOptions` typed as `string[]`

**Migration** (`f6a7b8c9d0e1`)
- Normalises legacy dict-shape `column_mappings` to canonical list with `column_index`
- Flattens `{raw, alias}` option objects to plain raw strings
- Tags `contains → replace` rules with `is_alias: True` where `match` appears in the options raw set
- Works on both SQLite and PostgreSQL; downgrade is a no-op

## Test plan

- [x] Run `alembic upgrade head` — confirm no errors on both local SQLite and prod PostgreSQL
- [x] Open an existing sheet config in the edit page — alias editor should display correctly with options populated from saved raw strings and aliases reconstructed from `is_alias` rules
- [x] Create a new sheet config via the wizard with a Google Form — alias editor shows options, editing an alias updates the corresponding rule with `is_alias: true`
- [x] Verify that TD-authored `contains → replace` rules whose `match` does not appear in the options list do **not** get `is_alias: true` and show up under "additional rules" in the alias editor
- [x] Run a sync — multi-select fields with aliases should still map correctly