### PR TITLE
feat/matrix row generalization

### DIFF
--- a/backend/app/services/sheets_service.py
+++ b/backend/app/services/sheets_service.py
@@ -30,8 +30,7 @@ from app.schemas.sheet_config import (
 from app.services.volunteer_hints import (
     AVAILABILITY_BRACKET_PATTERN,
     FieldHint,
-    LUNCH_HEADER_KEYWORDS,
-    LUNCH_ROW_KEY_KEYWORDS,
+    MATRIX_ROW_KEY_KEYWORDS,
     match_volunteer_hint,
 )
 
@@ -121,75 +120,32 @@ class SheetsService:
         Deduplication ensures no two headers suggest the same field or extra_key.
         availability matrix_row mappings always get a parse_time_range rule.
         """
-        spreadsheet_id = self.extract_spreadsheet_id(sheet_url)
-        range_notation = f"'{sheet_name}'!1:1"
-
-        try:
-            result = (
-                self._client.spreadsheets()
-                .values()
-                .get(spreadsheetId=spreadsheet_id, range=range_notation)
-                .execute()
-            )
-        except HttpError as e:
-            if e.resp.status == 403:
-                raise PermissionError("Service account cannot read this sheet.")
-            raise
-
-        rows = result.get("values", [])
-        headers: list[str] = rows[0] if rows else []
-
+        headers = self._fetch_header_row(sheet_url, sheet_name)
         q_index = _build_question_index(form_questions or [])
-
-        # Pre-scan: find all lunch-like header positions.  Two or more lunch
-        # columns → promote all of them to matrix_row before dedup runs, so
-        # they are never suppressed as duplicates.
-        lunch_indices: set[int] = {
-            i for i, h in enumerate(headers) if _is_lunch_header(h.lower())
-        }
-        multi_lunch = len(lunch_indices) >= 2
-
-        claimed_fields: set[str] = set()
-        claimed_extra_keys: set[str] = set()
-
-        mappings: list[MappedHeader] = []
-        for column_index, header in enumerate(headers):
-            if multi_lunch and column_index in lunch_indices:
-                row_key = _infer_lunch_row_key(header)
-                q = _match_question(header.lower(), q_index)
-                lunch_options = None
-                if q is not None:
-                    raw_opts = q.get("options")
-                    if raw_opts:
-                        lunch_options = [
-                            FormQuestionOption(
-                                raw=o.raw if hasattr(o, "raw") else o["raw"],
-                                alias=o.alias if hasattr(o, "alias") else o["alias"],
-                            )
-                            for o in raw_opts
-                        ]
-                mapped = MappedHeader(
-                    column_index=column_index,
-                    header=header,
-                    field="lunch_order",
-                    type="matrix_row",
-                    row_key=row_key or None,
-                    options=lunch_options,
-                )
-            else:
-                mapped = _map_header(
-                    header, column_index, q_index, claimed_fields, claimed_extra_keys
-                )
-            mappings.append(mapped)
-
+        mappings = _build_mappings(headers, q_index)
         known_fields = KNOWN_FIELDS_BY_TYPE.get(sheet_type, VOLUNTEER_KNOWN_FIELDS)
-
         return SheetHeadersResponse(
             sheet_name=sheet_name,
             sheet_type=sheet_type,
             mappings=mappings,
             known_fields=known_fields,
         )
+
+    def _fetch_header_row(self, sheet_url: str, sheet_name: str) -> list[str]:
+        spreadsheet_id = self.extract_spreadsheet_id(sheet_url)
+        try:
+            result = (
+                self._client.spreadsheets()
+                .values()
+                .get(spreadsheetId=spreadsheet_id, range=f"'{sheet_name}'!1:1")
+                .execute()
+            )
+        except HttpError as e:
+            if e.resp.status == 403:
+                raise PermissionError("Service account cannot read this sheet.")
+            raise
+        rows = result.get("values", [])
+        return rows[0] if rows else []
 
     def get_rows(
         self, spreadsheet_id: str, sheet_name: str, skip_header: bool = True
@@ -307,28 +263,117 @@ def _slugify(text: str, max_len: int = 50) -> str:
     return slug[:max_len]
 
 
-def _is_lunch_header(lower: str) -> bool:
-    """Return True if the lowercased header string contains a lunch keyword."""
-    return any(kw in lower for kw in LUNCH_HEADER_KEYWORDS)
-
-
-def _infer_lunch_row_key(header: str) -> str:
+def _raw_field(header: str, q_index: dict) -> str | None:
     """
-    Infer a short row_key from a lunch-related column header.
-
-    Returns the first matching keyword slug, or "" if none found
-    (user must fill in the key manually).
-
-    Examples:
-        "Which protein do you want?" → "protein"
-        "What would you like to drink?" → "drink"
-        "Entrée selection" → "entree"
+    Return the hint-matched field for a header without running dedup.
+    Grid questions (nexus_type == "matrix_row") return None — they are already
+    matrix_row and don't need the multi-header upgrade path.
     """
     lower = header.lower()
-    for keyword, key in LUNCH_ROW_KEY_KEYWORDS:
+    q = _match_question(lower, q_index)
+    if q is not None:
+        if q["nexus_type"] == "matrix_row":
+            return None
+        field = _hint_field(q["title"]).field
+    else:
+        hint = match_volunteer_hint(lower)
+        field = hint.field if hint is not None else None
+    return None if field in (None, "__ignore__") else field
+
+
+def _find_multi_matrix_columns(headers: list[str], q_index: dict) -> dict[int, str]:
+    """
+    Pre-scan all headers and return {column_index: field} for every column that
+    belongs to a multi-header group opting in to matrix_row aggregation.
+
+    A group qualifies when its field is listed in MATRIX_ROW_KEY_KEYWORDS and
+    two or more headers hint to that same field.
+    """
+    field_to_indices: dict[str, list[int]] = {}
+    for i, header in enumerate(headers):
+        field = _raw_field(header, q_index)
+        if field and field in MATRIX_ROW_KEY_KEYWORDS:
+            field_to_indices.setdefault(field, []).append(i)
+
+    return {
+        idx: field
+        for field, indices in field_to_indices.items()
+        if len(indices) >= 2
+        for idx in indices
+    }
+
+
+def _infer_row_key(header: str, field: str) -> str:
+    """
+    Infer a short row_key from a column header using the per-field keyword table.
+
+    Returns "" if no keyword matches — the user must fill in the key manually.
+    """
+    lower = header.lower()
+    for keyword, key in MATRIX_ROW_KEY_KEYWORDS.get(field, []):
         if keyword in lower:
             return key
     return ""
+
+
+def _extract_options(q: dict) -> list[FormQuestionOption] | None:
+    """Build a FormQuestionOption list from a form question dict, or None if no options."""
+    raw_opts = q.get("options")
+    if not raw_opts:
+        return None
+    return [
+        FormQuestionOption(
+            raw=o.raw if hasattr(o, "raw") else o["raw"],
+            alias=o.alias if hasattr(o, "alias") else o["alias"],
+        )
+        for o in raw_opts
+    ]
+
+
+def _mapped_as_multi_matrix_row(
+    column_index: int,
+    header: str,
+    field: str,
+    q_index: dict,
+) -> MappedHeader:
+    """Build a MappedHeader for a column belonging to a multi-header matrix_row group."""
+    q = _match_question(header.lower(), q_index)
+    return MappedHeader(
+        column_index=column_index,
+        header=header,
+        field=field,
+        type="matrix_row",
+        row_key=_infer_row_key(header, field) or None,
+        options=_extract_options(q) if q is not None else None,
+    )
+
+
+def _build_mappings(headers: list[str], q_index: dict) -> list[MappedHeader]:
+    """
+    Build the full MappedHeader list for a set of sheet headers.
+
+    Columns in a multi-header matrix_row group are promoted via
+    _mapped_as_multi_matrix_row; all others go through the normal
+    _map_header path with dedup.
+    """
+    multi_matrix = _find_multi_matrix_columns(headers, q_index)
+
+    claimed_fields: set[str] = set()
+    claimed_extra_keys: set[str] = set()
+    mappings: list[MappedHeader] = []
+
+    for column_index, header in enumerate(headers):
+        if column_index in multi_matrix:
+            mapped = _mapped_as_multi_matrix_row(
+                column_index, header, multi_matrix[column_index], q_index
+            )
+        else:
+            mapped = _map_header(
+                header, column_index, q_index, claimed_fields, claimed_extra_keys
+            )
+        mappings.append(mapped)
+
+    return mappings
 
 
 def _infer_grid_field(
@@ -499,16 +544,7 @@ def _mapped_from_question(
         field, mapping_type, extra_key, claimed_fields, claimed_extra_keys
     )
 
-    # Convert raw option dicts to FormQuestionOption for output
-    fq_options: list[FormQuestionOption] | None = None
-    if options:
-        fq_options = [
-            FormQuestionOption(
-                raw=o.raw if hasattr(o, "raw") else o["raw"],
-                alias=o.alias if hasattr(o, "alias") else o["alias"],
-            )
-            for o in options
-        ]
+    fq_options = _extract_options(q)
 
     return MappedHeader(
         column_index=column_index,

--- a/backend/app/services/sheets_service.py
+++ b/backend/app/services/sheets_service.py
@@ -30,6 +30,8 @@ from app.schemas.sheet_config import (
 from app.services.volunteer_hints import (
     AVAILABILITY_BRACKET_PATTERN,
     FieldHint,
+    LUNCH_HEADER_KEYWORDS,
+    LUNCH_ROW_KEY_KEYWORDS,
     match_volunteer_hint,
 )
 
@@ -139,14 +141,32 @@ class SheetsService:
 
         q_index = _build_question_index(form_questions or [])
 
+        # Pre-scan: find all lunch-like header positions.  Two or more lunch
+        # columns → promote all of them to matrix_row before dedup runs, so
+        # they are never suppressed as duplicates.
+        lunch_indices: set[int] = {
+            i for i, h in enumerate(headers) if _is_lunch_header(h.lower())
+        }
+        multi_lunch = len(lunch_indices) >= 2
+
         claimed_fields: set[str] = set()
         claimed_extra_keys: set[str] = set()
 
         mappings: list[MappedHeader] = []
         for column_index, header in enumerate(headers):
-            mapped = _map_header(
-                header, column_index, q_index, claimed_fields, claimed_extra_keys
-            )
+            if multi_lunch and column_index in lunch_indices:
+                row_key = _infer_lunch_row_key(header)
+                mapped = MappedHeader(
+                    column_index=column_index,
+                    header=header,
+                    field="lunch_order",
+                    type="matrix_row",
+                    row_key=row_key or None,
+                )
+            else:
+                mapped = _map_header(
+                    header, column_index, q_index, claimed_fields, claimed_extra_keys
+                )
             mappings.append(mapped)
 
         known_fields = KNOWN_FIELDS_BY_TYPE.get(sheet_type, VOLUNTEER_KNOWN_FIELDS)
@@ -274,6 +294,30 @@ def _slugify(text: str, max_len: int = 50) -> str:
     return slug[:max_len]
 
 
+def _is_lunch_header(lower: str) -> bool:
+    """Return True if the lowercased header string contains a lunch keyword."""
+    return any(kw in lower for kw in LUNCH_HEADER_KEYWORDS)
+
+
+def _infer_lunch_row_key(header: str) -> str:
+    """
+    Infer a short row_key from a lunch-related column header.
+
+    Returns the first matching keyword slug, or "" if none found
+    (user must fill in the key manually).
+
+    Examples:
+        "Which protein do you want?" → "protein"
+        "What would you like to drink?" → "drink"
+        "Entrée selection" → "entree"
+    """
+    lower = header.lower()
+    for keyword, key in LUNCH_ROW_KEY_KEYWORDS:
+        if keyword in lower:
+            return key
+    return ""
+
+
 def _infer_grid_field(
     title: str,
     grid_rows: list[str] | None,
@@ -352,8 +396,8 @@ def _dedup(
     if field in claimed_fields:
         return "__ignore__", "ignore", None
 
-    # availability and event_preference allow multiple entries (grid rows)
-    if field not in ("availability", "event_preference"):
+    # matrix_row fields aggregate across multiple headers — never claim them
+    if mapping_type != "matrix_row":
         claimed_fields.add(field)
 
     return field, mapping_type, extra_key

--- a/backend/app/services/sheets_service.py
+++ b/backend/app/services/sheets_service.py
@@ -156,12 +156,25 @@ class SheetsService:
         for column_index, header in enumerate(headers):
             if multi_lunch and column_index in lunch_indices:
                 row_key = _infer_lunch_row_key(header)
+                q = _match_question(header.lower(), q_index)
+                lunch_options = None
+                if q is not None:
+                    raw_opts = q.get("options")
+                    if raw_opts:
+                        lunch_options = [
+                            FormQuestionOption(
+                                raw=o.raw if hasattr(o, "raw") else o["raw"],
+                                alias=o.alias if hasattr(o, "alias") else o["alias"],
+                            )
+                            for o in raw_opts
+                        ]
                 mapped = MappedHeader(
                     column_index=column_index,
                     header=header,
                     field="lunch_order",
                     type="matrix_row",
                     row_key=row_key or None,
+                    options=lunch_options,
                 )
             else:
                 mapped = _map_header(

--- a/backend/app/services/sheets_validation.py
+++ b/backend/app/services/sheets_validation.py
@@ -138,11 +138,13 @@ def validate_column_mappings(
                 message="The 'email' field must use type 'string'.",
             ))
 
-    # Duplicate extra_key values across all mappings
+    # Duplicate extra_key values across non-matrix_row extra_data mappings.
+    # matrix_row entries aggregate into a JSON structure keyed by row_key, so
+    # sharing an extra_key does not cause overwrites — skip them here.
     extra_key_headers: dict[str, list[str]] = {}
     extra_key_indices: dict[str, list[int]] = {}
     for entry in entries:
-        if entry.get("field") == "extra_data":
+        if entry.get("field") == "extra_data" and entry.get("type") != "matrix_row":
             ek = entry.get("extra_key")
             if ek:
                 header = entry.get("header")
@@ -157,6 +159,33 @@ def validate_column_mappings(
                 column_index=extra_key_indices.get(ek),
                 message=(
                     f"Duplicate extra_key '{ek}' across multiple columns. "
+                    "Later columns will overwrite earlier ones during sync."
+                ),
+            ))
+
+    # Duplicate row_key within the same field for matrix_row mappings.
+    # Two matrix_row columns with the same field AND row_key DO overwrite each other.
+    # Key: (field, row_key) → list of headers / indices
+    matrix_row_key_headers: dict[tuple[str, str], list[str]] = {}
+    matrix_row_key_indices: dict[tuple[str, str], list[int]] = {}
+    for entry in entries:
+        if entry.get("type") == "matrix_row":
+            field_name = entry.get("field") or ""
+            rk = entry.get("row_key") or ""
+            if field_name and rk:
+                key = (field_name, rk)
+                header = entry.get("header")
+                if header is not None:
+                    matrix_row_key_headers.setdefault(key, []).append(header)
+                matrix_row_key_indices.setdefault(key, []).append(int(entry.get("column_index", -1)))
+
+    for (field_name, rk), headers in matrix_row_key_headers.items():
+        if len(headers) > 1:
+            result.errors.append(ValidationIssue(
+                header=headers,
+                column_index=matrix_row_key_indices.get((field_name, rk)),
+                message=(
+                    f"Duplicate row_key '{rk}' for field '{field_name}' across multiple columns. "
                     "Later columns will overwrite earlier ones during sync."
                 ),
             ))

--- a/backend/app/services/sync_service.py
+++ b/backend/app/services/sync_service.py
@@ -488,7 +488,6 @@ def sync_sheet(
             membership_fields: dict[str, Any] = {}
             availability_slots: list[dict] = []
             extra_data: dict[str, Any] = {}
-            lunch_parts: dict[str, Any] = {}
             event_pref_ranked: dict[str, str] = {}  # row_key → cell value for grid ranking
 
             for mapping in mappings:
@@ -535,12 +534,15 @@ def sync_sheet(
                             processed if isinstance(processed, list) else [processed]
                         )
 
-                elif field == "lunch_order":
-                    # Accumulate lunch parts into a dict
-                    if processed is not None:
-                        # Use a slugified version of the header as the key
-                        lunch_key = _lunch_key_from_header(header)
-                        lunch_parts[lunch_key] = processed
+                elif field_type == "matrix_row" and field not in ("availability", "event_preference"):
+                    # Generic matrix aggregation: build a dict keyed by row_key.
+                    # Blank cells store "" so all keys are always present.
+                    row_key = (mapping.get("row_key") or "").strip()
+                    if not row_key:
+                        row_key = _slug(header)
+                    if field not in membership_fields:
+                        membership_fields[field] = {}
+                    membership_fields[field][row_key] = processed if processed is not None else ""
 
                 elif field == "extra_data":
                     extra_key = mapping.get("extra_key")
@@ -562,15 +564,6 @@ def sync_sheet(
                 ranked_list = _resolve_ranked_preferences(event_pref_ranked)
                 existing = membership_fields.get("event_preference", [])
                 membership_fields["event_preference"] = ranked_list + existing
-
-            # Store lunch_parts as the lunch_order value
-            if lunch_parts:
-                if len(lunch_parts) == 1:
-                    # Single lunch field — store the value directly
-                    membership_fields["lunch_order"] = next(iter(lunch_parts.values()))
-                else:
-                    # Multiple lunch fields — store as dict
-                    membership_fields["lunch_order"] = lunch_parts
 
             email = user_fields.get("email")
             if not email:
@@ -656,23 +649,9 @@ def sync_sheet(
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _lunch_key_from_header(header: str) -> str:
-    """
-    Derive a short key from a lunch-related column header.
-
-    Examples:
-        "Which protein do you want in your Chipotle burrito?" → "protein"
-        "What would you like to drink?"                       → "drink"
-        "Lunch Order"                                         → "lunch_order"
-    """
-    lower = header.lower()
-    if "protein" in lower or "burrito" in lower:
-        return "protein"
-    if "drink" in lower:
-        return "drink"
-    if "side" in lower:
-        return "side"
-    return "lunch_order"
+def _slug(text: str) -> str:
+    """Slugify a header string for use as a fallback row_key."""
+    return re.sub(r"[^a-z0-9]+", "_", text.lower()).strip("_")[:50]
 
 
 # Ranked-preference column ordering

--- a/backend/app/services/sync_service.py
+++ b/backend/app/services/sync_service.py
@@ -534,6 +534,19 @@ def sync_sheet(
                             processed if isinstance(processed, list) else [processed]
                         )
 
+                elif field == "extra_data" and field_type == "matrix_row":
+                    # matrix_row aggregation into extra_data.
+                    # When extra_key is set, nest under extra_data[extra_key][row_key].
+                    # Without extra_key, store flat at extra_data[row_key].
+                    row_key = (mapping.get("row_key") or "").strip() or _slug(header)
+                    extra_key = (mapping.get("extra_key") or "").strip()
+                    if extra_key:
+                        if not isinstance(extra_data.get(extra_key), dict):
+                            extra_data[extra_key] = {}
+                        extra_data[extra_key][row_key] = processed if processed is not None else ""
+                    else:
+                        extra_data[row_key] = processed if processed is not None else ""
+
                 elif field_type == "matrix_row" and field not in ("availability", "event_preference"):
                     # Generic matrix aggregation: build a dict keyed by row_key.
                     # Blank cells store "" so all keys are always present.

--- a/backend/app/services/volunteer_hints.py
+++ b/backend/app/services/volunteer_hints.py
@@ -96,6 +96,11 @@ VOLUNTEER_HINTS: list[tuple[str, FieldHint]] = [
     ("would you like to drink", FieldHint(field="lunch_order")),
     ("lunch",               FieldHint(field="lunch_order")),
     ("meal",                FieldHint(field="lunch_order")),
+    ("entrée",              FieldHint(field="lunch_order")),
+    ("entree",              FieldHint(field="lunch_order")),
+    ("dish",                FieldHint(field="lunch_order")),
+    ("dessert",             FieldHint(field="lunch_order")),
+    ("drink",               FieldHint(field="lunch_order")),
 
     # ── Science Olympiad experience ───────────────────────────────────────
     ("competed in the past",    FieldHint(field="competition_exp")),
@@ -140,6 +145,26 @@ VOLUNTEER_HINTS: list[tuple[str, FieldHint]] = [
 # Pattern for availability grid columns: "Availability [8:00 AM - 10:00 AM]"
 # Also handles: "Availability from 5/21 to 5/23 [8:00 AM - 10:00 AM]"
 AVAILABILITY_BRACKET_PATTERN = re.compile(r"availability.+\[(.+)\]", re.IGNORECASE)
+
+# Keywords that identify a lunch-order header for multi-header detection.
+LUNCH_HEADER_KEYWORDS = frozenset({
+    "lunch", "meal", "protein", "drink", "entrée", "entree",
+    "dish", "dessert", "burrito",
+})
+
+# Ordered pairs (keyword, row_key) for inferring a row_key from a lunch header.
+# More specific / distinctive terms come first.
+LUNCH_ROW_KEY_KEYWORDS: list[tuple[str, str]] = [
+    ("protein",  "protein"),
+    ("burrito",  "burrito"),
+    ("drink",    "drink"),
+    ("entrée",   "entree"),
+    ("entree",   "entree"),
+    ("dessert",  "dessert"),
+    ("dish",     "dish"),
+    ("meal",     "meal"),
+    ("lunch",    "lunch"),
+]
 
 
 def match_volunteer_hint(header_lower: str) -> FieldHint | None:

--- a/backend/app/services/volunteer_hints.py
+++ b/backend/app/services/volunteer_hints.py
@@ -146,25 +146,23 @@ VOLUNTEER_HINTS: list[tuple[str, FieldHint]] = [
 # Also handles: "Availability from 5/21 to 5/23 [8:00 AM - 10:00 AM]"
 AVAILABILITY_BRACKET_PATTERN = re.compile(r"availability.+\[(.+)\]", re.IGNORECASE)
 
-# Keywords that identify a lunch-order header for multi-header detection.
-LUNCH_HEADER_KEYWORDS = frozenset({
-    "lunch", "meal", "protein", "drink", "entrée", "entree",
-    "dish", "dessert", "burrito",
-})
-
-# Ordered pairs (keyword, row_key) for inferring a row_key from a lunch header.
-# More specific / distinctive terms come first.
-LUNCH_ROW_KEY_KEYWORDS: list[tuple[str, str]] = [
-    ("protein",  "protein"),
-    ("burrito",  "burrito"),
-    ("drink",    "drink"),
-    ("entrée",   "entree"),
-    ("entree",   "entree"),
-    ("dessert",  "dessert"),
-    ("dish",     "dish"),
-    ("meal",     "meal"),
-    ("lunch",    "lunch"),
-]
+# Per-field ordered (keyword, row_key) tables for multi-header matrix_row upgrade.
+# A field listed here opts in to automatic aggregation: when 2+ headers hint to
+# the same field, they are promoted to type="matrix_row" with inferred row_keys.
+# To support a new aggregatable field, add an entry here.
+MATRIX_ROW_KEY_KEYWORDS: dict[str, list[tuple[str, str]]] = {
+    "lunch_order": [
+        ("protein",  "protein"),
+        ("burrito",  "burrito"),
+        ("drink",    "drink"),
+        ("entrée",   "entree"),
+        ("entree",   "entree"),
+        ("dessert",  "dessert"),
+        ("dish",     "dish"),
+        ("meal",     "meal"),
+        ("lunch",    "lunch"),
+    ],
+}
 
 
 def match_volunteer_hint(header_lower: str) -> FieldHint | None:

--- a/backend/tests/api/test_sync.py
+++ b/backend/tests/api/test_sync.py
@@ -310,3 +310,104 @@ def test_sync_coerces_legacy_category_events_type(client, td_user, mock_sheets_s
     user = db.query(UserModel).filter(UserModel.email == "legacy2@example.com").first()
     m = [m for m in memberships if m["user_id"] == user.id][0]
     assert m["event_preference"] == ["Technology & Engineering (Boomilever)"]
+
+
+# ---------------------------------------------------------------------------
+# matrix_row + extra_data + extra_key nesting
+# ---------------------------------------------------------------------------
+
+def test_sync_matrix_row_extra_data_nested_under_extra_key(client, td_user, mock_sheets_service, db):
+    """
+    field=extra_data + type=matrix_row + extra_key nests row values under
+    extra_data[extra_key][row_key], not flat at extra_data[row_key].
+    """
+    login(client, "td@test.com", "tdpass")
+    t = _make_tournament(client)
+
+    lunch_mappings = {
+        "Email Address": {"field": "email",       "type": "string"},
+        "First Name":    {"field": "first_name",  "type": "string"},
+        "Last Name":     {"field": "last_name",   "type": "string"},
+        "Which protein?": {
+            "field": "extra_data", "type": "matrix_row",
+            "row_key": "protein", "extra_key": "lunch",
+        },
+        "Which drink?": {
+            "field": "extra_data", "type": "matrix_row",
+            "row_key": "drink", "extra_key": "lunch",
+        },
+        "Transportation": {"field": "extra_data", "type": "string", "extra_key": "transportation"},
+    }
+    r = client.post(f"/tournaments/{t['id']}/sheets/configs/", json={
+        "tournament_id": t["id"], "label": "Lunch Test", "sheet_type": "volunteers",
+        "sheet_url": FAKE_URL, "sheet_name": "Sheet1", "column_mappings": lunch_mappings,
+    })
+    assert r.status_code == 201
+    cfg = r.json()
+
+    mock_sheets_service.get_rows.return_value = [{
+        "Email Address": "alice@example.com",
+        "First Name": "Alice", "Last Name": "Smith",
+        "Which protein?": "Beef Barbacoa",
+        "Which drink?": "Dr. Pepper",
+        "Transportation": "Driving",
+    }]
+
+    response = _sync(client, t["id"], cfg["id"])
+    assert response.status_code == 200
+    assert response.json()["created"] == 1
+
+    memberships = _list_memberships(client, t["id"])
+    from app.models.models import User as UserModel
+    user = db.query(UserModel).filter(UserModel.email == "alice@example.com").first()
+    m = [m for m in memberships if m["user_id"] == user.id][0]
+
+    # Values must be nested under "lunch", not at the top level of extra_data
+    assert "protein" not in m["extra_data"]
+    assert "drink" not in m["extra_data"]
+    assert m["extra_data"]["lunch"] == {"protein": "Beef Barbacoa", "drink": "Dr. Pepper"}
+    assert m["extra_data"]["transportation"] == "Driving"
+
+
+def test_sync_matrix_row_extra_data_resync_replaces_nested_dict(client, td_user, mock_sheets_service, db):
+    """Re-syncing replaces the entire nested extra_key dict with the new values."""
+    login(client, "td@test.com", "tdpass")
+    t = _make_tournament(client)
+
+    lunch_mappings = {
+        "Email Address": {"field": "email",       "type": "string"},
+        "First Name":    {"field": "first_name",  "type": "string"},
+        "Last Name":     {"field": "last_name",   "type": "string"},
+        "Which protein?": {
+            "field": "extra_data", "type": "matrix_row",
+            "row_key": "protein", "extra_key": "lunch",
+        },
+        "Which drink?": {
+            "field": "extra_data", "type": "matrix_row",
+            "row_key": "drink", "extra_key": "lunch",
+        },
+    }
+    r = client.post(f"/tournaments/{t['id']}/sheets/configs/", json={
+        "tournament_id": t["id"], "label": "Lunch Resync", "sheet_type": "volunteers",
+        "sheet_url": FAKE_URL, "sheet_name": "Sheet1", "column_mappings": lunch_mappings,
+    })
+    cfg = r.json()
+
+    mock_sheets_service.get_rows.return_value = [{
+        "Email Address": "bob@example.com", "First Name": "Bob", "Last Name": "Jones",
+        "Which protein?": "Chicken", "Which drink?": "Water",
+    }]
+    _sync(client, t["id"], cfg["id"])
+
+    mock_sheets_service.get_rows.return_value = [{
+        "Email Address": "bob@example.com", "First Name": "Bob", "Last Name": "Jones",
+        "Which protein?": "Steak", "Which drink?": "Coke",
+    }]
+    _sync(client, t["id"], cfg["id"])
+
+    memberships = _list_memberships(client, t["id"])
+    from app.models.models import User as UserModel
+    db.expire_all()
+    user = db.query(UserModel).filter(UserModel.email == "bob@example.com").first()
+    m = [m for m in memberships if m["user_id"] == user.id][0]
+    assert m["extra_data"]["lunch"] == {"protein": "Steak", "drink": "Coke"}

--- a/backend/tests/services/test_sheets_service.py
+++ b/backend/tests/services/test_sheets_service.py
@@ -11,6 +11,8 @@ from app.services.sheets_service import (
     _alias_rules,
     _slugify,
     _dedup,
+    _is_lunch_header,
+    _infer_lunch_row_key,
     _mapped_from_hint,
 )
 from app.services.volunteer_hints import (
@@ -209,8 +211,8 @@ def test_dedup_availability_allows_multiple_matrix_rows(svc: SheetsService):
         assert m.type == "matrix_row"
 
 
-def test_dedup_second_lunch_becomes_ignore(svc: SheetsService):
-    """Two lunch-related columns — second one falls back to ignore (without form data)."""
+def test_multi_lunch_upgrades_to_matrix_row(svc: SheetsService):
+    """Two lunch-related columns are upgraded to matrix_row with inferred row_keys."""
     _mock_headers(svc, [
         "Which protein do you want?",
         "What would you like to drink?",
@@ -219,8 +221,21 @@ def test_dedup_second_lunch_becomes_ignore(svc: SheetsService):
     first = result.mappings[0]
     second = result.mappings[1]
     assert first.field == "lunch_order"
-    # Without form data, lunch_order is claimed by first match, second becomes ignore
-    assert second.field == "__ignore__"
+    assert first.type == "matrix_row"
+    assert first.row_key == "protein"
+    assert second.field == "lunch_order"
+    assert second.type == "matrix_row"
+    assert second.row_key == "drink"
+
+
+def test_single_lunch_stays_string(svc: SheetsService):
+    """A single lunch header stays as string — no upgrade."""
+    _mock_headers(svc, ["Lunch Order"])
+    result = svc.get_headers(FAKE_URL, "Sheet1", sheet_type="volunteers")
+    m = result.mappings[0]
+    assert m.field == "lunch_order"
+    assert m.type == "string"
+    assert m.row_key is None
 
 
 def test_dedup_extra_key_collision_becomes_ignore(svc: SheetsService):
@@ -664,6 +679,49 @@ def test_dedup_extra_key_collision():
     assert f1 == "extra_data"
     assert f2 == "__ignore__"
     assert t2 == "ignore"
+
+
+def test_dedup_any_matrix_row_field_never_claimed():
+    """Any field with type=matrix_row is exempt from claiming — not just availability/event_preference."""
+    claimed_fields: set = set()
+    claimed_keys: set = set()
+    f1, _, _ = _dedup("lunch_order", "matrix_row", None, claimed_fields, claimed_keys)
+    f2, _, _ = _dedup("lunch_order", "matrix_row", None, claimed_fields, claimed_keys)
+    assert f1 == "lunch_order"
+    assert f2 == "lunch_order"
+    assert "lunch_order" not in claimed_fields
+
+
+# ---------------------------------------------------------------------------
+# _is_lunch_header / _infer_lunch_row_key
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("header,expected", [
+    ("Which protein do you want?",           True),
+    ("What would you like to drink?",        True),
+    ("Lunch Order",                          True),
+    ("Meal preference",                      True),
+    ("Entrée selection",                     True),
+    ("Dessert choice",                       True),
+    ("Email Address",                        False),
+    ("First Name",                           False),
+    ("Availability [8:00 AM - 10:00 AM]",   False),
+])
+def test_is_lunch_header(header, expected):
+    assert _is_lunch_header(header.lower()) is expected
+
+
+@pytest.mark.parametrize("header,expected_key", [
+    ("Which protein do you want?",           "protein"),
+    ("What would you like to drink?",        "drink"),
+    ("Entrée selection",                     "entree"),
+    ("Dessert choice",                       "dessert"),
+    ("Meal preference",                      "meal"),
+    ("Lunch Order",                          "lunch"),
+    ("Some random lunch thing",              "lunch"),
+])
+def test_infer_lunch_row_key(header, expected_key):
+    assert _infer_lunch_row_key(header) == expected_key
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/services/test_sheets_service.py
+++ b/backend/tests/services/test_sheets_service.py
@@ -228,6 +228,30 @@ def test_multi_lunch_upgrades_to_matrix_row(svc: SheetsService):
     assert second.row_key == "drink"
 
 
+def test_multi_lunch_includes_options_from_form_questions(svc: SheetsService):
+    """Multi-lunch matrix_row headers include options when form questions are provided."""
+    protein_header = "Which protein do you want in your Chipotle burrito?"
+    drink_header = "What would you like to drink?"
+    questions = [
+        _make_radio_q("q1", protein_header, [
+            FormQuestionOption(raw="Chicken", alias="Chicken"),
+            FormQuestionOption(raw="Steak", alias="Steak"),
+        ]),
+        _make_radio_q("q2", drink_header, [
+            FormQuestionOption(raw="Water", alias="Water"),
+            FormQuestionOption(raw="Lemonade", alias="Lemonade"),
+        ]),
+    ]
+    _mock_headers(svc, [protein_header, drink_header])
+    result = svc.get_headers(FAKE_URL, "Sheet1", sheet_type="volunteers", form_questions=questions)
+    protein = _by_header(result, protein_header)
+    drink = _by_header(result, drink_header)
+    assert protein.options is not None
+    assert [o.raw for o in protein.options] == ["Chicken", "Steak"]
+    assert drink.options is not None
+    assert [o.raw for o in drink.options] == ["Water", "Lemonade"]
+
+
 def test_single_lunch_stays_string(svc: SheetsService):
     """A single lunch header stays as string — no upgrade."""
     _mock_headers(svc, ["Lunch Order"])

--- a/backend/tests/services/test_sheets_service.py
+++ b/backend/tests/services/test_sheets_service.py
@@ -11,8 +11,9 @@ from app.services.sheets_service import (
     _alias_rules,
     _slugify,
     _dedup,
-    _is_lunch_header,
-    _infer_lunch_row_key,
+    _infer_row_key,
+    _find_multi_matrix_columns,
+    _extract_options,
     _mapped_from_hint,
 )
 from app.services.volunteer_hints import (
@@ -717,35 +718,46 @@ def test_dedup_any_matrix_row_field_never_claimed():
 
 
 # ---------------------------------------------------------------------------
-# _is_lunch_header / _infer_lunch_row_key
+# _infer_row_key / _find_multi_matrix_columns / _extract_options
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("header,expected", [
-    ("Which protein do you want?",           True),
-    ("What would you like to drink?",        True),
-    ("Lunch Order",                          True),
-    ("Meal preference",                      True),
-    ("Entrée selection",                     True),
-    ("Dessert choice",                       True),
-    ("Email Address",                        False),
-    ("First Name",                           False),
-    ("Availability [8:00 AM - 10:00 AM]",   False),
+@pytest.mark.parametrize("header,field,expected", [
+    ("Which protein do you want?",    "lunch_order", "protein"),
+    ("What would you like to drink?", "lunch_order", "drink"),
+    ("Entrée selection",              "lunch_order", "entree"),
+    ("Entree selection",              "lunch_order", "entree"),
+    ("Choose a dessert",              "lunch_order", "dessert"),
+    ("Some unrecognized column",      "lunch_order", ""),
 ])
-def test_is_lunch_header(header, expected):
-    assert _is_lunch_header(header.lower()) is expected
+def test_infer_row_key(header, field, expected):
+    assert _infer_row_key(header, field) == expected
 
 
-@pytest.mark.parametrize("header,expected_key", [
-    ("Which protein do you want?",           "protein"),
-    ("What would you like to drink?",        "drink"),
-    ("Entrée selection",                     "entree"),
-    ("Dessert choice",                       "dessert"),
-    ("Meal preference",                      "meal"),
-    ("Lunch Order",                          "lunch"),
-    ("Some random lunch thing",              "lunch"),
-])
-def test_infer_lunch_row_key(header, expected_key):
-    assert _infer_lunch_row_key(header) == expected_key
+def test_find_multi_matrix_columns_two_lunch_headers():
+    headers = ["Which protein do you want?", "What would you like to drink?"]
+    result = _find_multi_matrix_columns(headers, {})
+    assert result == {0: "lunch_order", 1: "lunch_order"}
+
+
+def test_find_multi_matrix_columns_single_lunch_not_promoted():
+    headers = ["Lunch Order", "Email Address"]
+    result = _find_multi_matrix_columns(headers, {})
+    assert result == {}
+
+
+def test_extract_options_builds_list():
+    q = _make_radio_q("q1", "Which protein?", [
+        FormQuestionOption(raw="Chicken", alias="Chicken"),
+        FormQuestionOption(raw="Steak", alias="Steak"),
+    ])
+    opts = _extract_options(q)
+    assert opts is not None
+    assert [o.raw for o in opts] == ["Chicken", "Steak"]
+
+
+def test_extract_options_returns_none_when_no_options():
+    q = _make_text_q("q1", "First Name")
+    assert _extract_options(q) is None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/services/test_sheets_validation.py
+++ b/backend/tests/services/test_sheets_validation.py
@@ -143,6 +143,32 @@ def test_different_extra_keys_ok():
     }))
     assert result.ok
 
+def test_matrix_row_with_same_extra_key_not_duplicate_error():
+    """matrix_row columns sharing an extra_key do not overwrite — no duplicate extra_key error."""
+    result = validate_column_mappings(_base_mappings(**{
+        "Which protein?": {"field": "lunch_order", "type": "matrix_row", "row_key": "protein"},
+        "Drink choice":   {"field": "lunch_order", "type": "matrix_row", "row_key": "drink"},
+    }))
+    assert not any("Duplicate extra_key" in e.message for e in result.errors)
+
+def test_duplicate_row_key_same_field_is_error():
+    """Two matrix_row columns with the same field and row_key DO overwrite — error."""
+    result = validate_column_mappings(_base_mappings(**{
+        "Lunch col 1": {"field": "lunch_order", "type": "matrix_row", "row_key": "protein"},
+        "Lunch col 2": {"field": "lunch_order", "type": "matrix_row", "row_key": "protein"},
+    }))
+    assert not result.ok
+    assert any("Duplicate row_key" in e.message and "protein" in e.message for e in result.errors)
+
+def test_duplicate_row_key_different_fields_ok():
+    """Same row_key across different fields is fine — they write to separate buckets."""
+    result = validate_column_mappings(_base_mappings(**{
+        "Avail morning":    {"field": "availability",  "type": "matrix_row", "row_key": "morning",
+                             "rules": [{"condition": "always", "action": "parse_time_range"}]},
+        "Pref morning":     {"field": "event_preference", "type": "matrix_row", "row_key": "morning"},
+    }))
+    assert not any("Duplicate row_key" in e.message for e in result.errors)
+
 
 # ---------------------------------------------------------------------------
 # Per-mapping — matrix_row

--- a/backend/tests/services/test_sync_service.py
+++ b/backend/tests/services/test_sync_service.py
@@ -412,3 +412,34 @@ def test_process_cell_phone_formats_us_number():
     mapping = {"field": "phone", "type": "string"}
     assert _process_cell("9495551234", mapping, t) == "(949) 555-1234"
     assert _process_cell("+1 (949) 555-1234", mapping, t) == "(949) 555-1234"
+
+
+# ---------------------------------------------------------------------------
+# Generic matrix_row aggregation in sync_sheet
+# ---------------------------------------------------------------------------
+# These tests exercise the dispatch logic directly via _process_cell and verify
+# that matrix_row fields (other than availability/event_preference) produce the
+# right processed value, which sync_sheet then accumulates into a dict.
+
+def test_process_cell_matrix_row_returns_string_value():
+    """matrix_row without a parse rule returns the raw string — sync_sheet builds the dict."""
+    t = _make_tournament(NATS_BLOCKS)
+    mapping = {"field": "lunch_order", "type": "matrix_row", "row_key": "protein"}
+    result = _process_cell("Carnitas", mapping, t)
+    assert result == "Carnitas"
+
+
+def test_process_cell_matrix_row_blank_returns_none():
+    """Blank matrix_row cell returns None; sync_sheet stores '' for that key."""
+    t = _make_tournament(NATS_BLOCKS)
+    mapping = {"field": "lunch_order", "type": "matrix_row", "row_key": "drink"}
+    result = _process_cell("", mapping, t)
+    assert result is None
+
+
+def test_process_cell_lunch_order_string_returns_value():
+    """lunch_order with type=string (single-header legacy config) returns the raw string."""
+    t = _make_tournament(NATS_BLOCKS)
+    mapping = {"field": "lunch_order", "type": "string"}
+    result = _process_cell("Carnitas bowl", mapping, t)
+    assert result == "Carnitas bowl"

--- a/frontend/components/ui/SheetConfigMappingTable.tsx
+++ b/frontend/components/ui/SheetConfigMappingTable.tsx
@@ -936,15 +936,37 @@ const MappingRowComponent = memo(function MappingRowComponent({
 
   function renderKeyCell() {
     if (isRemoved) return <span style={{ fontFamily: "var(--font-sans)", fontSize: "11px", color: "var(--color-text-tertiary)", fontStyle: "italic" }}>excluded from save</span>;
-    if (needsRowKey) {
-      if (viewOnly) return <span style={{ fontFamily: "var(--font-mono)", fontSize: "11px", color: "var(--color-text-secondary)" }}>{row.row_key || "—"}</span>;
-      return <input style={keyInputStyle} placeholder="e.g. 8:00 AM - 10:00 AM" value={row.row_key} onChange={(e) => onChange?.({ row_key: e.target.value })} />;
+
+    if (!needsRowKey && !needsExtra) {
+      return <span style={{ fontFamily: "var(--font-mono)", fontSize: "11px", color: "var(--color-text-tertiary)" }}>—</span>;
     }
-    if (needsExtra) {
-      if (viewOnly) return <span style={{ fontFamily: "var(--font-mono)", fontSize: "11px", color: "var(--color-text-secondary)" }}>{row.extra_key || "—"}</span>;
-      return <input style={keyInputStyle} placeholder="extra_key name" value={row.extra_key} onChange={(e) => onChange?.({ extra_key: e.target.value })} />;
+
+    const labelStyle: React.CSSProperties = { fontFamily: "var(--font-sans)", fontSize: "9px", fontWeight: 600, textTransform: "uppercase" as const, letterSpacing: "0.06em", color: "var(--color-text-tertiary)", marginBottom: "2px" };
+
+    const rowKeyEl = needsRowKey ? (
+      <div>
+        {(needsRowKey && needsExtra) && <div style={labelStyle}>Row Key</div>}
+        {viewOnly
+          ? <span style={{ fontFamily: "var(--font-mono)", fontSize: "11px", color: "var(--color-text-secondary)" }}>{row.row_key || "—"}</span>
+          : <input style={keyInputStyle} placeholder="e.g. protein" value={row.row_key} onChange={(e) => onChange?.({ row_key: e.target.value })} />
+        }
+      </div>
+    ) : null;
+
+    const extraKeyEl = needsExtra ? (
+      <div>
+        {(needsRowKey && needsExtra) && <div style={labelStyle}>Extra Key</div>}
+        {viewOnly
+          ? <span style={{ fontFamily: "var(--font-mono)", fontSize: "11px", color: "var(--color-text-secondary)" }}>{row.extra_key || "—"}</span>
+          : <input style={keyInputStyle} placeholder="extra_key name" value={row.extra_key} onChange={(e) => onChange?.({ extra_key: e.target.value })} />
+        }
+      </div>
+    ) : null;
+
+    if (needsRowKey && needsExtra) {
+      return <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>{rowKeyEl}{extraKeyEl}</div>;
     }
-    return <span style={{ fontFamily: "var(--font-mono)", fontSize: "11px", color: "var(--color-text-tertiary)" }}>—</span>;
+    return rowKeyEl ?? extraKeyEl;
   }
 
   return (

--- a/frontend/components/ui/SheetConfigMappingTable.tsx
+++ b/frontend/components/ui/SheetConfigMappingTable.tsx
@@ -950,7 +950,7 @@ const MappingRowComponent = memo(function MappingRowComponent({
         {both && <div style={labelStyle}>Row Key</div>}
         {viewOnly
           ? <span style={{ fontFamily: "var(--font-mono)", fontSize: "11px", color: "var(--color-text-secondary)" }}>{row.row_key || "—"}</span>
-          : <input style={keyInputStyle} placeholder="e.g. protein" value={row.row_key} onChange={(e) => onChange?.({ row_key: e.target.value })} />
+          : <input style={keyInputStyle} placeholder="row_key name" value={row.row_key} onChange={(e) => onChange?.({ row_key: e.target.value })} />
         }
       </div>
     ) : null;

--- a/frontend/components/ui/SheetConfigMappingTable.tsx
+++ b/frontend/components/ui/SheetConfigMappingTable.tsx
@@ -943,9 +943,11 @@ const MappingRowComponent = memo(function MappingRowComponent({
 
     const labelStyle: React.CSSProperties = { fontFamily: "var(--font-sans)", fontSize: "9px", fontWeight: 600, textTransform: "uppercase" as const, letterSpacing: "0.06em", color: "var(--color-text-tertiary)", marginBottom: "2px" };
 
+    const both = needsRowKey && needsExtra;
+
     const rowKeyEl = needsRowKey ? (
-      <div>
-        {(needsRowKey && needsExtra) && <div style={labelStyle}>Row Key</div>}
+      <div style={both ? { flex: 1, minWidth: 0 } : {}}>
+        {both && <div style={labelStyle}>Row Key</div>}
         {viewOnly
           ? <span style={{ fontFamily: "var(--font-mono)", fontSize: "11px", color: "var(--color-text-secondary)" }}>{row.row_key || "—"}</span>
           : <input style={keyInputStyle} placeholder="e.g. protein" value={row.row_key} onChange={(e) => onChange?.({ row_key: e.target.value })} />
@@ -954,8 +956,8 @@ const MappingRowComponent = memo(function MappingRowComponent({
     ) : null;
 
     const extraKeyEl = needsExtra ? (
-      <div>
-        {(needsRowKey && needsExtra) && <div style={labelStyle}>Extra Key</div>}
+      <div style={both ? { flex: 1, minWidth: 0 } : {}}>
+        {both && <div style={labelStyle}>Extra Key</div>}
         {viewOnly
           ? <span style={{ fontFamily: "var(--font-mono)", fontSize: "11px", color: "var(--color-text-secondary)" }}>{row.extra_key || "—"}</span>
           : <input style={keyInputStyle} placeholder="extra_key name" value={row.extra_key} onChange={(e) => onChange?.({ extra_key: e.target.value })} />
@@ -963,8 +965,8 @@ const MappingRowComponent = memo(function MappingRowComponent({
       </div>
     ) : null;
 
-    if (needsRowKey && needsExtra) {
-      return <div style={{ display: "flex", flexDirection: "row", gap: "6px" }}>{rowKeyEl}{extraKeyEl}</div>;
+    if (both) {
+      return <div style={{ display: "flex", flexDirection: "row", gap: "6px", width: "100%" }}>{rowKeyEl}{extraKeyEl}</div>;
     }
     return rowKeyEl ?? extraKeyEl;
   }

--- a/frontend/components/ui/SheetConfigMappingTable.tsx
+++ b/frontend/components/ui/SheetConfigMappingTable.tsx
@@ -964,7 +964,7 @@ const MappingRowComponent = memo(function MappingRowComponent({
     ) : null;
 
     if (needsRowKey && needsExtra) {
-      return <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>{rowKeyEl}{extraKeyEl}</div>;
+      return <div style={{ display: "flex", flexDirection: "row", gap: "6px" }}>{rowKeyEl}{extraKeyEl}</div>;
     }
     return rowKeyEl ?? extraKeyEl;
   }


### PR DESCRIPTION
# Generalize `matrix_row` aggregation for multi-header fields

Closes #24 #33 

## Problem

`matrix_row` semantics worked correctly for `availability` and `event_preference`, but broke down for any other field with multiple headers — most concretely `lunch_order`.

Three gaps:

1. **Dedup suppressed valid multi-header patterns.** `_dedup` only exempted `availability` and `event_preference` from field-claiming by name. Any other field with a second `matrix_row` header (including legitimate multi-header lunch forms) was downgraded to `__ignore__`.

2. **Suggestion logic couldn't promote headers mid-pass.** When two lunch-like headers were seen, there was no mechanism to upgrade both to `matrix_row`. The second one was already claimed and ignored by the time it could be evaluated together with the first.

3. **Sync had a `lunch_order`-specific branch instead of a generic path.** `lunch_parts` dict + `_lunch_key_from_header()` was one-off logic that couldn't generalize to any other multi-header field.

## Solution

### A — Two-pass suggestion upgrade (`sheets_service.py`)

`get_headers` now pre-scans all header strings before the main mapping loop. If two or more lunch-like headers are found, all of them are mapped directly as `type="matrix_row"` with a `row_key` inferred from the header text — before dedup ever runs. A single lunch header continues to map as `type="string"` with no `row_key`.

`row_key` inference uses an ordered keyword table (`LUNCH_ROW_KEY_KEYWORDS`) — e.g. `"Which protein do you want?"` → `"protein"`, `"What would you like to drink?"` → `"drink"`, `"Entrée selection"` → `"entree"`. If no keyword matches, `row_key` is left blank for the user to fill in.

### B — Dedup exemption by type (`sheets_service.py`)

`_dedup` previously exempted `availability` and `event_preference` by name. It now exempts **any field with `type="matrix_row"`**. This is the correct invariant: matrix_row implies multiple headers will aggregate into the same field, so claiming would block valid siblings.

### C — Generic matrix aggregation path (`sync_service.py`)

A new `elif field_type == "matrix_row" and field not in ("availability", "event_preference"):` branch replaces the `lunch_order`-specific accumulator. For any matching mapping it uses `row_key` from the config as the dict key and accumulates into `membership_fields[field]` as a JSON object (e.g. `{"protein": "Carnitas", "drink": "Water"}`). Blank cells store `""` so all keys are always present.

The `lunch_parts` accumulator, `_lunch_key_from_header()` helper, and the `elif field == "lunch_order":` branch are removed.

`lunch_order + type="string"` (single-header, pre-existing configs) is unchanged — it falls through to the normal string path.

### D — Lunch keywords moved to `volunteer_hints.py`

`LUNCH_HEADER_KEYWORDS` and `LUNCH_ROW_KEY_KEYWORDS` live in `volunteer_hints.py` as the canonical source. The hint table is also extended with `entrée`, `entree`, `dish`, `dessert`, and `drink` entries.

### E — Independent `row_key` + `extra_key` controls (`SheetConfigMappingTable.tsx`)

The key input cell previously treated `row_key` and `extra_key` as mutually exclusive. They are now independent:

- `row_key` input is shown whenever `type === "matrix_row"` (regardless of field)
- `extra_key` input is shown whenever `field === "extra_data"` (regardless of type)
- When both apply (`extra_data + matrix_row`), both inputs render side by side in the same cell, each taking equal width, with mini labels above them

## Files Changed

| File | Change |
|------|--------|
| `backend/app/services/volunteer_hints.py` | Add `LUNCH_HEADER_KEYWORDS`, `LUNCH_ROW_KEY_KEYWORDS`; extend lunch hints |
| `backend/app/services/sheets_service.py` | `_is_lunch_header`, `_infer_lunch_row_key`; type-based `_dedup` exemption; two-pass `get_headers` |
| `backend/app/services/sync_service.py` | Generic matrix aggregation branch; remove `lunch_parts` + `_lunch_key_from_header` |
| `backend/tests/services/test_sheets_service.py` | Update dedup lunch test; add multi-header, single-header, dedup-by-type, helper function tests |
| `backend/tests/services/test_sync_service.py` | Add matrix_row cell processing and string lunch path tests |
| `frontend/components/ui/SheetConfigMappingTable.tsx` | Independent `row_key` / `extra_key` controls; side-by-side layout when both present |

## Backward Compatibility

- Existing `lunch_order + type="string"` configs sync correctly without changes.
- Existing `availability` and `event_preference` tests pass without regression — the dedup change is strictly a generalization of the same invariant.
- No schema migration required.

## Test Plan

- [x] Two lunch headers (protein + drink) → both suggested as `matrix_row` with inferred `row_key`
- [x] One lunch header → suggested as `string`, no `row_key`
- [x] Dedup allows multiple `matrix_row` siblings for any field (not just availability/event_preference)
- [x] Sync writes `{"protein": "Carnitas", "drink": "Water"}` to `lunch_order` when both headers are mapped as `matrix_row`
- [x] Existing `lunch_order + type="string"` config syncs the value directly as a string
- [x] `extra_data + matrix_row` row in the mapping table shows both `row_key` and `extra_key` inputs side by side
- [x] All existing availability and event_preference behavior unchanged