### PR TITLE
fix/laggy sidebar

### DIFF
--- a/frontend/app/dashboard/[tournamentId]/layout.tsx
+++ b/frontend/app/dashboard/[tournamentId]/layout.tsx
@@ -29,7 +29,7 @@ function TournamentShell({
         tournamentId={tournamentId}
       />
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, overflow: "hidden", marginLeft: COLLAPSED_W }}>
-        <Topbar showDropdown tournamentId={tournamentId} showAvatar />
+        <Topbar showDropdown tournamentId={tournamentId} showAvatar sidebarExpanded={sidebarExpanded} />
         <main style={{ flex: 1, overflowY: "auto", padding: "22px 24px" }}>
           {children}
         </main>

--- a/frontend/app/dashboard/[tournamentId]/layout.tsx
+++ b/frontend/app/dashboard/[tournamentId]/layout.tsx
@@ -24,8 +24,7 @@ function TournamentShell({
   return (
     <div style={{ display: "flex", height: "100vh", overflow: "hidden", background: "var(--color-bg)" }}>
       <Sidebar
-        expanded={sidebarExpanded}
-        onToggle={() => setSidebarExpanded((v) => !v)}
+        onExpandedChange={setSidebarExpanded}
         tournamentId={tournamentId}
       />
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, overflow: "hidden", marginLeft: COLLAPSED_W }}>

--- a/frontend/app/dashboard/[tournamentId]/layout.tsx
+++ b/frontend/app/dashboard/[tournamentId]/layout.tsx
@@ -3,7 +3,7 @@
 import { ReactNode, useState, useEffect } from "react";
 import { use } from "react";
 import { TournamentProvider, useTournament } from "@/lib/useTournament";
-import { Sidebar, COLLAPSED_W, EXPANDED_W } from "@/components/layout/Sidebar";
+import { Sidebar, COLLAPSED_W } from "@/components/layout/Sidebar";
 import { Topbar } from "@/components/layout/Topbar";
 import { tournamentsApi } from "@/lib/api";
 
@@ -28,7 +28,7 @@ function TournamentShell({
         onToggle={() => setSidebarExpanded((v) => !v)}
         tournamentId={tournamentId}
       />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, overflow: "hidden" }}>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, overflow: "hidden", marginLeft: COLLAPSED_W }}>
         <Topbar showDropdown tournamentId={tournamentId} showAvatar />
         <main style={{ flex: 1, overflowY: "auto", padding: "22px 24px" }}>
           {children}

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -38,10 +38,10 @@ export function Sidebar({ expanded, onToggle, tournamentId }: SidebarProps) {
   return (
     <aside style={{
       width,
-      flexShrink: 0,
       height: "100vh",
-      position: "sticky",
+      position: "fixed",
       top: 0,
+      left: 0,
       background: "var(--color-surface)",
       borderRight: "1px solid var(--color-border)",
       display: "flex",

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
@@ -9,7 +10,6 @@ import {
   IconVolunteers,
   IconSheets,
   IconSettings,
-  IconChevronRight,
 } from "@/components/ui/Icons";
 
 export const COLLAPSED_W = 52;
@@ -25,32 +25,45 @@ const NAV_ITEMS = [
 ];
 
 interface SidebarProps {
-  expanded: boolean;
-  onToggle: () => void;
+  onExpandedChange?: (expanded: boolean) => void;
   tournamentId: string | number;
 }
 
-export function Sidebar({ expanded, onToggle, tournamentId }: SidebarProps) {
+export function Sidebar({ onExpandedChange, tournamentId }: SidebarProps) {
+  const [expanded, setExpanded] = useState(false);
   const pathname = usePathname();
   const width = expanded ? EXPANDED_W : COLLAPSED_W;
   const base = `/dashboard/${tournamentId}`;
 
+  function handleMouseEnter() {
+    setExpanded(true);
+    onExpandedChange?.(true);
+  }
+
+  function handleMouseLeave() {
+    setExpanded(false);
+    onExpandedChange?.(false);
+  }
+
   return (
-    <aside style={{
-      width,
-      height: "100vh",
-      position: "fixed",
-      top: 0,
-      left: 0,
-      background: "var(--color-surface)",
-      borderRight: "1px solid var(--color-border)",
-      display: "flex",
-      flexDirection: "column",
-      alignItems: expanded ? "stretch" : "center",
-      transition: "width 0.2s ease",
-      overflow: "hidden",
-      zIndex: 50,
-    }}>
+    <aside
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      style={{
+        width,
+        height: "100vh",
+        position: "fixed",
+        top: 0,
+        left: 0,
+        background: "var(--color-surface)",
+        borderRight: "1px solid var(--color-border)",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: expanded ? "stretch" : "center",
+        transition: "width 0.2s ease",
+        overflow: "hidden",
+        zIndex: 50,
+      }}>
       {/* Header */}
       <div style={{
         height: "52px",
@@ -136,38 +149,6 @@ export function Sidebar({ expanded, onToggle, tournamentId }: SidebarProps) {
           );
         })}
       </nav>
-
-      {/* Toggle — pinned to bottom */}
-      <div style={{
-        padding: "10px 6px",
-        borderTop: "1px solid var(--color-border)",
-        display: "flex", alignItems: "center",
-        justifyContent: expanded ? "flex-end" : "center",
-        paddingRight: expanded ? "10px" : "6px",
-      }}>
-        <button
-          onClick={onToggle}
-          title={expanded ? "Collapse sidebar" : "Expand sidebar"}
-          style={{
-            width: "38px", height: "38px",
-            borderRadius: "var(--radius-md)",
-            border: "none", background: "transparent",
-            color: "var(--color-text-tertiary)", cursor: "pointer",
-            display: "flex", alignItems: "center", justifyContent: "center",
-            transition: "background var(--transition-fast), color var(--transition-fast)",
-          }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.background = "var(--color-accent-subtle)";
-            e.currentTarget.style.color = "var(--color-text-primary)";
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.background = "transparent";
-            e.currentTarget.style.color = "var(--color-text-tertiary)";
-          }}
-        >
-          <IconChevronRight expanded={expanded} />
-        </button>
-      </div>
     </aside>
   );
 }

--- a/frontend/components/layout/Topbar.tsx
+++ b/frontend/components/layout/Topbar.tsx
@@ -6,12 +6,14 @@ import { useTournament, Tournament } from "@/lib/useTournament";
 import { NewTournamentModal } from "@/components/ui/NewTournamentModal";
 import { UserAvatar } from "@/components/ui/UserAvatar";
 import { IconChevronDown, IconPlus } from "@/components/ui/Icons";
+import { COLLAPSED_W, EXPANDED_W } from "@/components/layout/Sidebar";
 
 interface TopbarProps {
   showWordmark?: boolean;
   showDropdown?: boolean;
   showAvatar?: boolean;
   tournamentId?: string | number;
+  sidebarExpanded?: boolean;
 }
 
 // ─── Tournament Dropdown ──────────────────────────────────────────────────────
@@ -137,14 +139,18 @@ export function Topbar({
   showDropdown = false,
   showAvatar = true,
   tournamentId,
+  sidebarExpanded = false,
 }: TopbarProps) {
+  const leftPad = (sidebarExpanded ? EXPANDED_W - COLLAPSED_W : 0) + 16;
+
   return (
     <header style={{
       height: "52px",
       background: "var(--color-surface)",
       borderBottom: "1px solid var(--color-border)",
       display: "flex", alignItems: "center",
-      paddingLeft: "16px", paddingRight: "20px",
+      paddingLeft: leftPad, paddingRight: "20px",
+      transition: "padding-left 0.2s ease",
       gap: "12px",
       position: "sticky",
       top: 0,


### PR DESCRIPTION
# Fix: laggy sidebar animation on volunteers page

## Problem

The sidebar expand/collapse animation was noticeably laggy on the volunteers page. The root cause was that animating `width` on a flex child forces the browser to recalculate layout (reflow) on every animation frame. On most pages this is cheap, but the volunteers table — with 18+ columns, dynamic `extraKeys` columns, mixed `whiteSpace: normal` cells, and `minWidth`/`maxWidth` constraints — made each frame's reflow expensive enough to cause visible jank.

## Solution

Three commits, each building on the last:

### 1. Eliminate content reflow during animation (`fc25348`)

- Changed `Sidebar` from `position: sticky` to `position: fixed`, removing it from the flex flow entirely
- Added a static `marginLeft: COLLAPSED_W` (52px, never changes) to the content div in the layout
- The sidebar's `width` transition now runs in isolation — the main content area never changes width during the animation, so the volunteers table is never reflowed

The sidebar now overlays the content when expanded (140px overlap), consistent with how VS Code, Linear, and Notion handle this pattern.

### 2. Sync topbar padding with sidebar (`afc02a5`)

Since the content area no longer shifts during the animation, the topbar needed its own way to stay clear of the expanded sidebar. Added a `sidebarExpanded` prop to `Topbar` that transitions `paddingLeft` between `16px` (collapsed) and `156px` (expanded) using the same `0.2s ease` timing. The topbar's reflow cost is trivial — it's a single flat `<header>` with a few elements.

### 3. Replace toggle button with hover expand/collapse (`dcf54f9`)

- Removed the chevron toggle button at the bottom of the sidebar
- Sidebar now owns its `expanded` state internally, driven by `onMouseEnter`/`onMouseLeave`
- Fires `onExpandedChange` callback so the layout can keep `sidebarExpanded` in sync for the topbar

## Files changed

- `frontend/components/layout/Sidebar.tsx` — fixed position, hover state, removed toggle button
- `frontend/components/layout/Topbar.tsx` — `sidebarExpanded` prop, `paddingLeft` transition
- `frontend/app/dashboard/[tournamentId]/layout.tsx` — static `marginLeft`, wired `onExpandedChange` and `sidebarExpanded`