### PR TITLE
feat/field value type split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ CLAUDE_OUTPUT_BEHAVIOR.md
 
 # Misc
 password.txt
+docs/

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,1 +1,1 @@
-get_raw_forms_json.py
+utils/

--- a/backend/alembic/versions/23ff6e84620b_split_field_value_type.py
+++ b/backend/alembic/versions/23ff6e84620b_split_field_value_type.py
@@ -37,8 +37,8 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision: str = 'a8f3c1d2e9b0'
-down_revision: Union[str, None] = 'f6a7b8c9d0e1'
+revision: str = '23ff6e84620b'
+down_revision: Union[str, None] = '2f2394fbbc02'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/alembic/versions/23ff6e84620b_split_field_value_type.py
+++ b/backend/alembic/versions/23ff6e84620b_split_field_value_type.py
@@ -1,0 +1,185 @@
+"""split column mapping type into field_type + value_type
+
+Revision ID: 23ff6e84620b
+Revises: 2f2394fbbc02
+Create Date: 2026-04-07 18:34:15.649967
+
+Data migration for sheet_configs.column_mappings:
+
+1. Translate old flat `type` field → field_type + value_type using the map below.
+2. Rename row_key → group_key on any mapping entry that has it.
+3. On any mapping entry with a rules list containing a rule where
+   action == "parse_time_range" or action == "parse_availability":
+     - Remove that rule from the list.
+     - Set value_type = "time_range" on the mapping (overrides the default
+       "text" from step 1 if needed).
+
+Old type → (field_type, value_type):
+  string       → single, text
+  boolean      → single, boolean
+  integer      → single, number
+  multi_select → list,   text
+  matrix_row   → group,  text
+  ignore       → ignore, null
+
+Legacy type aliases are also handled:
+  availability_row → matrix_row → group, text
+  category_events  → string    → single, text
+
+This migration is irreversible. Take a backup before running.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'a8f3c1d2e9b0'
+down_revision: Union[str, None] = 'f6a7b8c9d0e1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# ---------------------------------------------------------------------------
+# Type coercion map
+# ---------------------------------------------------------------------------
+
+# Legacy type aliases → canonical old type
+_LEGACY_TYPE_ALIASES: dict[str, str] = {
+    "availability_row": "matrix_row",
+    "category_events":  "string",
+}
+
+# Old type → (field_type, value_type | None)
+_TYPE_TO_FIELD_VALUE: dict[str, tuple[str, str | None]] = {
+    "string":       ("single", "text"),
+    "boolean":      ("single", "boolean"),
+    "integer":      ("single", "number"),
+    "multi_select": ("list",   "text"),
+    "matrix_row":   ("group",  "text"),
+    "ignore":       ("ignore", None),
+}
+
+# Rule actions that expressed time_range coercion — now replaced by value_type
+_TIME_RANGE_ACTIONS = {"parse_time_range", "parse_availability"}
+
+
+# ---------------------------------------------------------------------------
+# Per-entry migration helper
+# ---------------------------------------------------------------------------
+
+def _migrate_entry(entry: dict) -> tuple[dict, bool]:
+    """
+    Migrate a single column mapping entry in place.
+    Returns (updated_entry, changed).
+    """
+    if not isinstance(entry, dict):
+        return entry, False
+
+    changed = False
+
+    # 1. Translate old `type` → field_type + value_type
+    if "type" in entry and "field_type" not in entry:
+        old_type = str(entry.pop("type"))
+        changed = True
+
+        # Resolve legacy aliases first
+        old_type = _LEGACY_TYPE_ALIASES.get(old_type, old_type)
+
+        field_type, value_type = _TYPE_TO_FIELD_VALUE.get(old_type, ("single", "text"))
+        entry["field_type"] = field_type
+        if value_type is not None:
+            entry.setdefault("value_type", value_type)
+        # ignore has no value_type — remove if somehow set
+        if field_type == "ignore":
+            entry.pop("value_type", None)
+
+    # 2. Rename row_key → group_key
+    if "row_key" in entry and "group_key" not in entry:
+        entry["group_key"] = entry.pop("row_key")
+        changed = True
+
+    # 3. Remove parse_time_range / parse_availability rules,
+    #    set value_type = "time_range" if any were found.
+    rules = entry.get("rules")
+    if rules and isinstance(rules, list):
+        new_rules = []
+        found_time_range = False
+        for rule in rules:
+            if isinstance(rule, dict) and rule.get("action") in _TIME_RANGE_ACTIONS:
+                found_time_range = True
+                changed = True
+                # Drop this rule — do not append
+            else:
+                new_rules.append(rule)
+        if found_time_range:
+            entry["rules"] = new_rules if new_rules else None
+            if entry.get("rules") is None:
+                entry.pop("rules", None)
+            entry["value_type"] = "time_range"
+        elif rules != new_rules:
+            entry["rules"] = new_rules
+
+    return entry, changed
+
+
+# ---------------------------------------------------------------------------
+# Migration
+# ---------------------------------------------------------------------------
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name  # "sqlite" or "postgresql"
+
+    rows = bind.execute(
+        sa.text("SELECT id, column_mappings FROM sheet_configs")
+    ).fetchall()
+
+    for row in rows:
+        config_id: int = row[0]
+        raw = row[1]
+
+        if raw is None:
+            continue
+
+        # SQLite returns JSON columns as strings; PostgreSQL as native objects.
+        mappings = json.loads(raw) if isinstance(raw, str) else raw
+
+        if not isinstance(mappings, list):
+            continue
+
+        any_changed = False
+        for i, entry in enumerate(mappings):
+            updated, changed = _migrate_entry(entry)
+            if changed:
+                mappings[i] = updated
+                any_changed = True
+
+        if not any_changed:
+            continue
+
+        serialized = json.dumps(mappings)
+        if dialect == "postgresql":
+            bind.execute(
+                sa.text(
+                    "UPDATE sheet_configs"
+                    " SET column_mappings = cast(:cm AS jsonb)"
+                    " WHERE id = :id"
+                ),
+                {"cm": serialized, "id": config_id},
+            )
+        else:
+            bind.execute(
+                sa.text(
+                    "UPDATE sheet_configs SET column_mappings = :cm WHERE id = :id"
+                ),
+                {"cm": serialized, "id": config_id},
+            )
+
+
+def downgrade() -> None:
+    # Field type split is irreversible — downgrade is a no-op.
+    pass

--- a/backend/app/api/routes/sheets.py
+++ b/backend/app/api/routes/sheets.py
@@ -114,7 +114,7 @@ def validate_mappings(
     payload: ValidateMappingsRequest,
     current_user: User = Depends(require_permission(MANAGE_TOURNAMENT)),
 ):
-    result = validate_column_mappings([m.model_dump() for m in payload.column_mappings])
+    result = validate_column_mappings(payload.column_mappings)
     return result.to_response_dict()
 
 

--- a/backend/app/schemas/sheet_config.py
+++ b/backend/app/schemas/sheet_config.py
@@ -458,7 +458,14 @@ class SheetConfigReadWithWarnings(SheetConfigRead):
 
 
 class ValidateMappingsRequest(BaseModel):
-    column_mappings: list[ColumnMappingEntry] = []
+    """
+    Accepts raw mapping dicts without running ColumnMappingEntry validators.
+
+    Validation is intentionally deferred to validate_column_mappings() so that
+    all errors are returned as structured ValidationIssue objects rather than
+    raw Pydantic 422 responses that the frontend cannot parse.
+    """
+    column_mappings: list[dict[str, Any]] = []
 
     @field_validator("column_mappings", mode="before")
     @classmethod

--- a/backend/app/schemas/sheet_config.py
+++ b/backend/app/schemas/sheet_config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, field_validator, model_validator
 
 
 # ---------------------------------------------------------------------------
@@ -63,22 +63,41 @@ KNOWN_FIELDS_BY_TYPE: dict[str, list[str]] = {
 }
 
 # ---------------------------------------------------------------------------
-# Valid column mapping types
+# Field type — the shape/structure of the output value.
+# Value type — the coercion applied to each individual value.
 # ---------------------------------------------------------------------------
-VALID_MAPPING_TYPES: set[str] = {
-    "string",        # store value as-is
-    "ignore",        # skip this column entirely
-    "boolean",       # "Yes"/"No" → True/False
-    "integer",       # parse to int
-    "multi_select",  # split on delimiter → JSON array; rules run before splitting
-    "matrix_row",    # one row of a grid question → merged into availability JSON
-                     # requires row_key; use parse_time_range rule to parse time slots
+VALID_FIELD_TYPES: set[str] = {
+    "single",   # One value → scalar
+    "list",     # Multiple values → array
+    "group",    # Keyed values → dict (requires group_key)
+    "ignore",   # No output
+}
+
+VALID_VALUE_TYPES: set[str] = {
+    "text",        # String, no coercion
+    "number",      # Int or float
+    "boolean",     # "Yes"/"No", "True"/"False" → bool
+    "date",        # Date or datetime string → parsed date
+    "time_range",  # "8:00 AM - 10:00 AM" style → slot object
 }
 
 VALID_SHEET_TYPES = {"volunteers", "events"}
 
 # ---------------------------------------------------------------------------
-# Backwards compatibility
+# Legacy type → (field_type, value_type) coercion map.
+# Applied on read before validation so old saved configs still load.
+# ---------------------------------------------------------------------------
+_LEGACY_FIELD_VALUE_MAP: dict[str, tuple[str, str | None]] = {
+    "string":       ("single", "text"),
+    "boolean":      ("single", "boolean"),
+    "integer":      ("single", "number"),
+    "multi_select": ("list",   "text"),
+    "matrix_row":   ("group",  "text"),
+    "ignore":       ("ignore", None),
+}
+
+# ---------------------------------------------------------------------------
+# Backwards compatibility — legacy mapping type aliases
 # ---------------------------------------------------------------------------
 _LEGACY_TYPE_MAP: dict[str, str] = {
     "availability_row": "matrix_row",
@@ -92,6 +111,7 @@ LEGACY_SHEET_TYPE_MAP: dict[str, str] = {
 
 
 def coerce_legacy_type(type_value: str) -> str:
+    """Coerce old type aliases (availability_row, category_events) to their canonical old types."""
     if type_value in _LEGACY_TYPE_MAP:
         import logging
         new_type = _LEGACY_TYPE_MAP[type_value]
@@ -102,6 +122,31 @@ def coerce_legacy_type(type_value: str) -> str:
         )
         return new_type
     return type_value
+
+
+def coerce_legacy_mapping(data: dict) -> dict:
+    """
+    Translate old type/row_key fields to field_type/value_type/group_key on read.
+
+    This runs on ColumnMapping model_validator(mode='before') so old DB data
+    loaded before the migration still parses correctly. After the migration,
+    all stored data already uses field_type/value_type/group_key.
+    """
+    data = dict(data)
+
+    # Translate old flat `type` field → field_type + value_type
+    if "type" in data and "field_type" not in data:
+        old_type = coerce_legacy_type(str(data.pop("type")))
+        field_type, value_type = _LEGACY_FIELD_VALUE_MAP.get(old_type, ("single", "text"))
+        data["field_type"] = field_type
+        if value_type is not None:
+            data.setdefault("value_type", value_type)
+
+    # Rename row_key → group_key
+    if "row_key" in data and "group_key" not in data:
+        data["group_key"] = data.pop("row_key")
+
+    return data
 
 
 # ---------------------------------------------------------------------------
@@ -122,15 +167,10 @@ VALID_RULE_ACTIONS: set[str] = {
     "prepend",
     "append",
     "discard",
-    "parse_time_range",    # canonical — parses time block on matrix_row cells
-    "parse_availability",  # legacy alias — accepted on read, treated identically
 }
 
 # Actions that require a `value` field
 _ACTIONS_REQUIRING_VALUE: set[str] = {"set", "replace", "prepend", "append"}
-
-# Actions that perform time-range parsing (canonical + legacy alias)
-PARSE_TIME_RANGE_ACTIONS: set[str] = {"parse_time_range", "parse_availability"}
 
 
 class ParseRule(BaseModel):
@@ -199,8 +239,9 @@ class ColumnMapping(BaseModel):
     model_config = {"populate_by_name": True}
 
     field: str
-    type: str
-    row_key: str | None = None
+    field_type: str
+    value_type: str | None = None
+    group_key: str | None = None
     extra_key: str | None = None
     rules: list[ParseRule] | None = None
     delimiter: str | None = None
@@ -215,10 +256,12 @@ class ColumnMapping(BaseModel):
         kwargs.setdefault("exclude_none", True)
         return super().model_dump(**kwargs)
 
-    @field_validator("type", mode="before")
+    @model_validator(mode="before")
     @classmethod
-    def coerce_type(cls, v: str) -> str:
-        return coerce_legacy_type(v)
+    def coerce_legacy_fields(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            return coerce_legacy_mapping(data)
+        return data
 
     @field_validator("field")
     @classmethod
@@ -227,12 +270,33 @@ class ColumnMapping(BaseModel):
             raise ValueError(f"Unknown field '{v}'. Must be one of: {ALL_KNOWN_FIELDS}")
         return v
 
-    @field_validator("type")
+    @field_validator("field_type")
     @classmethod
-    def validate_type(cls, v: str) -> str:
-        if v not in VALID_MAPPING_TYPES:
-            raise ValueError(f"type must be one of: {VALID_MAPPING_TYPES}")
+    def validate_field_type(cls, v: str) -> str:
+        if v not in VALID_FIELD_TYPES:
+            raise ValueError(f"field_type must be one of: {VALID_FIELD_TYPES}")
         return v
+
+    @field_validator("value_type")
+    @classmethod
+    def validate_value_type(cls, v: str | None) -> str | None:
+        if v is not None and v not in VALID_VALUE_TYPES:
+            raise ValueError(f"value_type must be one of: {VALID_VALUE_TYPES}")
+        return v
+
+    @model_validator(mode="after")
+    def validate_field_value_combo(self) -> "ColumnMapping":
+        if self.field_type == "ignore":
+            if self.value_type is not None:
+                raise ValueError("value_type must be null when field_type is 'ignore'")
+        else:
+            if self.value_type is None:
+                raise ValueError(
+                    f"value_type is required when field_type is '{self.field_type}'"
+                )
+        if self.field_type == "group" and not self.group_key:
+            raise ValueError("group_key is required when field_type is 'group'")
+        return self
 
 
 class ColumnMappingEntry(ColumnMapping):
@@ -240,7 +304,7 @@ class ColumnMappingEntry(ColumnMapping):
     A single mapped sheet column with stable identity by index.
 
     This is the canonical shape for persisted/read mapping data:
-      {column_index, header, field, type, ...}
+      {column_index, header, field, field_type, value_type, ...}
     """
     column_index: int
     header: str
@@ -263,7 +327,7 @@ def normalize_column_mappings_input(
       {"Header": {field, type, ...}, ...}
 
     Canonical list shape:
-      [{"column_index": 0, "header": "Header", field, type, ...}, ...]
+      [{"column_index": 0, "header": "Header", field, field_type, ...}, ...]
     """
     if value is None:
         return []
@@ -300,9 +364,6 @@ def normalize_column_mappings_input(
 # One entry per sheet column, with suggested mapping and form enrichment
 # already cross-referenced by the service layer. The frontend maps these
 # directly to RichMappingRow objects — no client-side cross-referencing needed.
-#
-# google_type has been removed — the backend resolves the mapping type fully.
-# The frontend Type dropdown is always editable by the TD.
 # ---------------------------------------------------------------------------
 class MappedHeader(BaseModel):
     """
@@ -311,8 +372,9 @@ class MappedHeader(BaseModel):
     column_index: int = 0
     header:      str
     field:       str
-    type:        str
-    row_key:     str | None = None
+    field_type:  str
+    value_type:  str | None = None
+    group_key:   str | None = None
     extra_key:   str | None = None
     rules:       list[ParseRule] | None = None
     delimiter:   str | None = None
@@ -455,10 +517,11 @@ class SheetHeadersResponse(BaseModel):
     sheet_name: str
     sheet_type: str
     mappings:   list[MappedHeader]
-    known_fields:          list[str] = VOLUNTEER_KNOWN_FIELDS
-    valid_types:           list[str] = list(VALID_MAPPING_TYPES)
-    valid_rule_conditions: list[str] = list(VALID_RULE_CONDITIONS)
-    valid_rule_actions:    list[str] = list(VALID_RULE_ACTIONS)
+    known_fields:           list[str] = VOLUNTEER_KNOWN_FIELDS
+    valid_field_types:      list[str] = list(VALID_FIELD_TYPES)
+    valid_value_types:      list[str] = list(VALID_VALUE_TYPES)
+    valid_rule_conditions:  list[str] = list(VALID_RULE_CONDITIONS)
+    valid_rule_actions:     list[str] = list(VALID_RULE_ACTIONS)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/sheets_service.py
+++ b/backend/app/services/sheets_service.py
@@ -2,12 +2,12 @@
 Google Sheets API wrapper + header mapping logic.
 
 SheetsService handles all Google Sheets API calls.
-Pure functions handle header → field/type mapping with this priority:
-  1. Form question match → field from hints, type from form's nexus_type
-  2. Hint-based detection → field from hints, type defaults to "string"
+Pure functions handle header → field/field_type/value_type mapping with this priority:
+  1. Form question match → field from hints, field_type/value_type from form's nexus_type
+  2. Hint-based detection → field from hints, field_type defaults to "single"/value_type "text"
   3. Fall back to __ignore__/ignore
 
-Exception: availability bracket pattern always → matrix_row regardless of form data.
+Exception: availability bracket pattern always → group/time_range regardless of form data.
 """
 from __future__ import annotations
 import json
@@ -39,10 +39,15 @@ SCOPES = [
     "https://www.googleapis.com/auth/forms.body.readonly",
 ]
 
-# The parse_time_range rule — auto-attached to availability matrix_row mappings
-_PARSE_TIME_RANGE_RULE = ParseRule(
-    condition="always", case_sensitive=False, action="parse_time_range"
-)
+# Internal translation: nexus_type (old form-service values) → (field_type, value_type)
+_NEXUS_TYPE_TO_FIELD_VALUE: dict[str, tuple[str, str | None]] = {
+    "string":       ("single", "text"),
+    "boolean":      ("single", "boolean"),
+    "integer":      ("single", "number"),
+    "multi_select": ("list",   "text"),
+    "matrix_row":   ("group",  "text"),
+    "ignore":       ("ignore", None),
+}
 
 
 class SheetsService:
@@ -118,7 +123,7 @@ class SheetsService:
         already cross-referenced — no client-side merging needed.
 
         Deduplication ensures no two headers suggest the same field or extra_key.
-        availability matrix_row mappings always get a parse_time_range rule.
+        Availability group mappings get value_type="time_range" automatically.
         """
         headers = self._fetch_header_row(sheet_url, sheet_name)
         q_index = _build_question_index(form_questions or [])
@@ -267,7 +272,7 @@ def _raw_field(header: str, q_index: dict) -> str | None:
     """
     Return the hint-matched field for a header without running dedup.
     Grid questions (nexus_type == "matrix_row") return None — they are already
-    matrix_row and don't need the multi-header upgrade path.
+    group type and don't need the multi-header upgrade path.
     """
     lower = header.lower()
     q = _match_question(lower, q_index)
@@ -284,7 +289,7 @@ def _raw_field(header: str, q_index: dict) -> str | None:
 def _find_multi_matrix_columns(headers: list[str], q_index: dict) -> dict[int, str]:
     """
     Pre-scan all headers and return {column_index: field} for every column that
-    belongs to a multi-header group opting in to matrix_row aggregation.
+    belongs to a multi-header group opting in to group aggregation.
 
     A group qualifies when its field is listed in MATRIX_ROW_KEY_KEYWORDS and
     two or more headers hint to that same field.
@@ -305,7 +310,7 @@ def _find_multi_matrix_columns(headers: list[str], q_index: dict) -> dict[int, s
 
 def _infer_row_key(header: str, field: str) -> str:
     """
-    Infer a short row_key from a column header using the per-field keyword table.
+    Infer a short group_key from a column header using the per-field keyword table.
 
     Returns "" if no keyword matches — the user must fill in the key manually.
     """
@@ -330,20 +335,21 @@ def _extract_options(q: dict) -> list[FormQuestionOption] | None:
     ]
 
 
-def _mapped_as_multi_matrix_row(
+def _mapped_as_multi_group_row(
     column_index: int,
     header: str,
     field: str,
     q_index: dict,
 ) -> MappedHeader:
-    """Build a MappedHeader for a column belonging to a multi-header matrix_row group."""
+    """Build a MappedHeader for a column belonging to a multi-header group aggregation."""
     q = _match_question(header.lower(), q_index)
     return MappedHeader(
         column_index=column_index,
         header=header,
         field=field,
-        type="matrix_row",
-        row_key=_infer_row_key(header, field) or None,
+        field_type="group",
+        value_type="text",
+        group_key=_infer_row_key(header, field) or None,
         options=_extract_options(q) if q is not None else None,
     )
 
@@ -352,9 +358,8 @@ def _build_mappings(headers: list[str], q_index: dict) -> list[MappedHeader]:
     """
     Build the full MappedHeader list for a set of sheet headers.
 
-    Columns in a multi-header matrix_row group are promoted via
-    _mapped_as_multi_matrix_row; all others go through the normal
-    _map_header path with dedup.
+    Columns in a multi-header group are promoted via _mapped_as_multi_group_row;
+    all others go through the normal _map_header path with dedup.
     """
     multi_matrix = _find_multi_matrix_columns(headers, q_index)
 
@@ -364,7 +369,7 @@ def _build_mappings(headers: list[str], q_index: dict) -> list[MappedHeader]:
 
     for column_index, header in enumerate(headers):
         if column_index in multi_matrix:
-            mapped = _mapped_as_multi_matrix_row(
+            mapped = _mapped_as_multi_group_row(
                 column_index, header, multi_matrix[column_index], q_index
             )
         else:
@@ -382,7 +387,7 @@ def _infer_grid_field(
     grid_columns: list[str] | None,
 ) -> str:
     """
-    Infer matrix_row field with grid-aware heuristics.
+    Infer group field with grid-aware heuristics.
 
     Matrix questions should map to either availability or event_preference.
     Generic hints like "major" in long question text should not override this.
@@ -427,7 +432,7 @@ def _infer_grid_field(
 
 def _dedup(
     field: str,
-    mapping_type: str,
+    field_type: str,
     extra_key: str | None,
     claimed_fields: set[str],
     claimed_extra_keys: set[str],
@@ -437,28 +442,28 @@ def _dedup(
 
     - __ignore__ is never claimed.
     - extra_data: if extra_key already taken → fall back to ignore.
-    - availability: never claimed (multiple matrix_row rows share it).
+    - availability: never claimed (multiple group rows share it).
     - event_preference: never claimed (multiple grid rows can share it).
     - All other fields: if already claimed → fall back to ignore.
     """
     if field == "__ignore__":
-        return field, mapping_type, extra_key
+        return field, field_type, extra_key
 
     if field == "extra_data":
         if extra_key and extra_key in claimed_extra_keys:
             return "__ignore__", "ignore", None
         if extra_key:
             claimed_extra_keys.add(extra_key)
-        return field, mapping_type, extra_key
+        return field, field_type, extra_key
 
     if field in claimed_fields:
         return "__ignore__", "ignore", None
 
-    # matrix_row fields aggregate across multiple headers — never claim them
-    if mapping_type != "matrix_row":
+    # group fields aggregate across multiple headers — never claim them
+    if field_type != "group":
         claimed_fields.add(field)
 
-    return field, mapping_type, extra_key
+    return field, field_type, extra_key
 
 
 def _map_header(
@@ -473,7 +478,7 @@ def _map_header(
 
     Priority order:
     1. Form question match (if q_index populated)
-    2. Hint-based detection (field only, type defaults to "string")
+    2. Hint-based detection (field only, field_type defaults to "single"/"text")
     3. Fall back to __ignore__/ignore
     """
     lower = header.lower()
@@ -496,7 +501,7 @@ def _mapped_from_question(
     Build a MappedHeader from a matched form question dict.
 
     Field comes from hints (semantic meaning of the question title).
-    Type comes from the form question's nexus_type (google question type).
+    field_type/value_type come from the form question's nexus_type.
     """
     nexus_type: str = q["nexus_type"]
     title: str = q["title"]
@@ -504,44 +509,41 @@ def _mapped_from_question(
     grid_rows: list[str] | None = q.get("grid_rows")
     grid_columns: list[str] | None = q.get("grid_columns")
 
-    # Grid questions → matrix_row, always get parse_time_range rule
+    # Grid questions → group field_type
     if nexus_type == "matrix_row":
-        # Determine field with grid-aware inference so generic keywords like
-        # "major" inside long event question text do not misclassify.
         grid_field = _infer_grid_field(title, grid_rows, grid_columns)
+        group_key = _extract_row_key(header)
 
-        row_key = _extract_row_key(header)
-
-        rules: list[ParseRule] | None = None
-        if grid_field == "availability":
-            rules = [_PARSE_TIME_RANGE_RULE]
+        # Availability groups use time_range value_type; others use text
+        value_type = "time_range" if grid_field == "availability" else "text"
 
         return MappedHeader(
             column_index=column_index,
             header=header,
             field=grid_field,
-            type="matrix_row",
-            row_key=row_key,
-            rules=rules,
+            field_type="group",
+            value_type=value_type,
+            group_key=group_key,
             grid_rows=grid_rows,
             grid_columns=grid_columns,
         )
 
-    # Non-grid questions — field from hint, type from form
+    # Non-grid questions — field from hint, field_type/value_type from nexus_type
     hint = _hint_field(title)
     field = hint.field
-    mapping_type = nexus_type  # form type takes priority
+
+    field_type, value_type = _NEXUS_TYPE_TO_FIELD_VALUE.get(nexus_type, ("single", "text"))
 
     rules = None
-    if options and mapping_type == "multi_select":
+    if options and field_type == "list":
         rules = _alias_rules(options) or None
 
     extra_key: str | None = hint.extra_key
     if field == "extra_data" and not extra_key:
         extra_key = _slugify(title)
 
-    field, mapping_type, extra_key = _dedup(
-        field, mapping_type, extra_key, claimed_fields, claimed_extra_keys
+    field, field_type, extra_key = _dedup(
+        field, field_type, extra_key, claimed_fields, claimed_extra_keys
     )
 
     fq_options = _extract_options(q)
@@ -550,7 +552,8 @@ def _mapped_from_question(
         column_index=column_index,
         header=header,
         field=field,
-        type=mapping_type,
+        field_type=field_type,
+        value_type=value_type,
         extra_key=extra_key,
         rules=rules,
         options=fq_options,
@@ -567,23 +570,23 @@ def _mapped_from_hint(
     """
     Build a MappedHeader using hint-based detection (no form data available).
 
-    Field comes from hints. Type always defaults to "string" except for
-    the availability bracket pattern which forces "matrix_row".
+    Field comes from hints. field_type always defaults to "single"/"text" except for
+    the availability bracket pattern which forces "group"/"time_range".
     """
     # Availability grid pattern: "Availability [8:00 AM - 10:00 AM]"
     avail_match = AVAILABILITY_BRACKET_PATTERN.search(header)
     if avail_match:
-        row_key = avail_match.group(1).strip()
+        group_key = avail_match.group(1).strip()
         return MappedHeader(
             column_index=column_index,
             header=header,
             field="availability",
-            type="matrix_row",
-            row_key=row_key,
-            rules=[_PARSE_TIME_RANGE_RULE],
+            field_type="group",
+            value_type="time_range",
+            group_key=group_key,
         )
 
-    # Try volunteer hints — field only, type defaults to "string"
+    # Try volunteer hints — field only, field_type defaults to "single"/"text"
     hint = match_volunteer_hint(lower)
     if hint is not None:
         field = hint.field
@@ -591,22 +594,31 @@ def _mapped_from_hint(
 
         # __ignore__ → ignore type
         if field == "__ignore__":
-            return MappedHeader(column_index=column_index, header=header, field="__ignore__", type="ignore")
+            return MappedHeader(
+                column_index=column_index,
+                header=header,
+                field="__ignore__",
+                field_type="ignore",
+            )
 
         # extra_data without a pre-defined extra_key → slugify the header
         if field == "extra_data" and not extra_key:
             extra_key = _slugify(header)
 
-        mapping_type = "string"
-        field, mapping_type, extra_key = _dedup(
-            field, mapping_type, extra_key, claimed_fields, claimed_extra_keys
+        field_type = "single"
+        value_type: str | None = "text"
+        field, field_type, extra_key = _dedup(
+            field, field_type, extra_key, claimed_fields, claimed_extra_keys
         )
+        if field_type == "ignore":
+            value_type = None
 
         return MappedHeader(
             column_index=column_index,
             header=header,
             field=field,
-            type=mapping_type,
+            field_type=field_type,
+            value_type=value_type,
             extra_key=extra_key or None,
         )
 
@@ -615,5 +627,5 @@ def _mapped_from_hint(
         column_index=column_index,
         header=header,
         field="__ignore__",
-        type="ignore",
+        field_type="ignore",
     )

--- a/backend/app/services/sheets_validation.py
+++ b/backend/app/services/sheets_validation.py
@@ -11,7 +11,7 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
-from app.schemas.sheet_config import coerce_legacy_mapping
+from app.schemas.sheet_config import coerce_legacy_mapping, VALID_RULE_ACTIONS, VALID_RULE_CONDITIONS
 
 
 @dataclass
@@ -280,6 +280,21 @@ def validate_column_mappings(
                         f"Rule action '{action}' is no longer valid. "
                         "Use value_type='time_range' on the mapping instead."
                     ),
+                ))
+            elif action not in VALID_RULE_ACTIONS:
+                result.errors.append(ValidationIssue(
+                    header=header,
+                    column_index=col_idx,
+                    rule_index=i,
+                    message=f"Unknown rule action '{action}'. Must be one of: {sorted(VALID_RULE_ACTIONS)}.",
+                ))
+
+            if condition not in VALID_RULE_CONDITIONS:
+                result.errors.append(ValidationIssue(
+                    header=header,
+                    column_index=col_idx,
+                    rule_index=i,
+                    message=f"Unknown rule condition '{condition}'. Must be one of: {sorted(VALID_RULE_CONDITIONS)}.",
                 ))
 
             # regex must compile

--- a/backend/app/services/sheets_validation.py
+++ b/backend/app/services/sheets_validation.py
@@ -11,6 +11,8 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
+from app.schemas.sheet_config import coerce_legacy_mapping
+
 
 @dataclass
 class ValidationIssue:
@@ -62,9 +64,10 @@ class ValidationResult:
         }
 
 
-# Both the canonical action and its legacy alias are valid for parse_time_range.
-# sync_service._apply_rules() accepts both.
-PARSE_TIME_RANGE_ACTIONS = {"parse_time_range", "parse_availability"}
+# Removed rule actions that are no longer valid (parse_time_range / parse_availability).
+# These were previously used for availability coercion; time_range coercion is now
+# expressed via value_type="time_range" on the mapping, not via a rule action.
+_REMOVED_RULE_ACTIONS = {"parse_time_range", "parse_availability"}
 
 
 def _normalise_mapping_entries(
@@ -73,16 +76,17 @@ def _normalise_mapping_entries(
     if isinstance(mappings, dict):
         out: list[dict[str, Any]] = []
         for idx, (header, mapping) in enumerate(mappings.items()):
+            entry = coerce_legacy_mapping(dict(mapping))
             out.append({
                 "column_index": idx,
                 "header": header,
-                **dict(mapping),
+                **entry,
             })
         return out
 
     out: list[dict[str, Any]] = []
     for idx, entry in enumerate(mappings):
-        d = dict(entry)
+        d = coerce_legacy_mapping(dict(entry))
         out.append({
             "column_index": d.get("column_index", idx),
             "header": d.get("header"),
@@ -109,11 +113,11 @@ def validate_column_mappings(
     # Config-level checks
     # ------------------------------------------------------------------
 
-    # Email must be mapped exactly once
+    # Email must be mapped exactly once (field_type != "ignore")
     email_mappings = [
         (e.get("header"), int(e.get("column_index", -1)))
         for e in entries
-        if e.get("field") == "email" and e.get("type") != "ignore"
+        if e.get("field") == "email" and e.get("field_type") != "ignore"
     ]
     if not email_mappings:
         result.errors.append(ValidationIssue(
@@ -129,22 +133,35 @@ def validate_column_mappings(
             message=f"Multiple columns mapped to 'email': {labels}. Only one is allowed.",
         ))
 
-    # email field must be string type
+    # email field must be single/text type
     for entry in entries:
-        if entry.get("field") == "email" and entry.get("type") not in ("string", "ignore"):
+        if (
+            entry.get("field") == "email"
+            and entry.get("field_type") not in ("single", "ignore")
+        ):
             result.errors.append(ValidationIssue(
                 header=entry.get("header"),
                 column_index=entry.get("column_index"),
-                message="The 'email' field must use type 'string'.",
+                message="The 'email' field must use field_type 'single' with value_type 'text'.",
+            ))
+        elif (
+            entry.get("field") == "email"
+            and entry.get("field_type") == "single"
+            and entry.get("value_type") not in ("text", None)
+        ):
+            result.errors.append(ValidationIssue(
+                header=entry.get("header"),
+                column_index=entry.get("column_index"),
+                message="The 'email' field must use field_type 'single' with value_type 'text'.",
             ))
 
-    # Duplicate extra_key values across non-matrix_row extra_data mappings.
-    # matrix_row entries aggregate into a JSON structure keyed by row_key, so
+    # Duplicate extra_key values across non-group extra_data mappings.
+    # group entries aggregate into a JSON structure keyed by group_key, so
     # sharing an extra_key does not cause overwrites — skip them here.
     extra_key_headers: dict[str, list[str]] = {}
     extra_key_indices: dict[str, list[int]] = {}
     for entry in entries:
-        if entry.get("field") == "extra_data" and entry.get("type") != "matrix_row":
+        if entry.get("field") == "extra_data" and entry.get("field_type") != "group":
             ek = entry.get("extra_key")
             if ek:
                 header = entry.get("header")
@@ -163,29 +180,29 @@ def validate_column_mappings(
                 ),
             ))
 
-    # Duplicate row_key within the same field for matrix_row mappings.
-    # Two matrix_row columns with the same field AND row_key DO overwrite each other.
-    # Key: (field, row_key) → list of headers / indices
-    matrix_row_key_headers: dict[tuple[str, str], list[str]] = {}
-    matrix_row_key_indices: dict[tuple[str, str], list[int]] = {}
+    # Duplicate group_key within the same field for group mappings.
+    # Two group columns with the same field AND group_key DO overwrite each other.
+    # Key: (field, group_key) → list of headers / indices
+    group_key_headers: dict[tuple[str, str], list[str]] = {}
+    group_key_indices: dict[tuple[str, str], list[int]] = {}
     for entry in entries:
-        if entry.get("type") == "matrix_row":
+        if entry.get("field_type") == "group":
             field_name = entry.get("field") or ""
-            rk = entry.get("row_key") or ""
-            if field_name and rk:
-                key = (field_name, rk)
+            gk = entry.get("group_key") or ""
+            if field_name and gk:
+                key = (field_name, gk)
                 header = entry.get("header")
                 if header is not None:
-                    matrix_row_key_headers.setdefault(key, []).append(header)
-                matrix_row_key_indices.setdefault(key, []).append(int(entry.get("column_index", -1)))
+                    group_key_headers.setdefault(key, []).append(header)
+                group_key_indices.setdefault(key, []).append(int(entry.get("column_index", -1)))
 
-    for (field_name, rk), headers in matrix_row_key_headers.items():
+    for (field_name, gk), headers in group_key_headers.items():
         if len(headers) > 1:
             result.errors.append(ValidationIssue(
                 header=headers,
-                column_index=matrix_row_key_indices.get((field_name, rk)),
+                column_index=group_key_indices.get((field_name, gk)),
                 message=(
-                    f"Duplicate row_key '{rk}' for field '{field_name}' across multiple columns. "
+                    f"Duplicate group_key '{gk}' for field '{field_name}' across multiple columns. "
                     "Later columns will overwrite earlier ones during sync."
                 ),
             ))
@@ -197,15 +214,16 @@ def validate_column_mappings(
         header = entry.get("header")
         col_idx = entry.get("column_index")
         field_name = entry.get("field")
-        field_type = entry.get("type")
+        field_type = entry.get("field_type")
+        value_type = entry.get("value_type")
         rules: list[dict] = entry.get("rules") or []
 
-        # matrix_row requires row_key
-        if field_type == "matrix_row" and not entry.get("row_key"):
+        # group requires group_key
+        if field_type == "group" and not entry.get("group_key"):
             result.errors.append(ValidationIssue(
                 header=header,
                 column_index=col_idx,
-                message="matrix_row type requires a row_key.",
+                message="field_type 'group' requires a group_key.",
             ))
 
         # ignore type must map to __ignore__
@@ -213,37 +231,35 @@ def validate_column_mappings(
             result.errors.append(ValidationIssue(
                 header=header,
                 column_index=col_idx,
-                message="type 'ignore' requires field '__ignore__'.",
+                message="field_type 'ignore' requires field '__ignore__'.",
             ))
 
-        # extra_data requires extra_key
-        if field_name == "extra_data" and not entry.get("extra_key"):
+        # extra_data requires extra_key (unless it's a group — group_key serves as key)
+        if field_name == "extra_data" and field_type != "group" and not entry.get("extra_key"):
             result.errors.append(ValidationIssue(
                 header=header,
                 column_index=col_idx,
                 message="Field 'extra_data' requires an extra_key.",
             ))
 
-        # delimiter only valid on multi_select
-        if entry.get("delimiter") is not None and field_type != "multi_select":
+        # delimiter only valid on list field_type
+        if entry.get("delimiter") is not None and field_type != "list":
             result.errors.append(ValidationIssue(
                 header=header,
                 column_index=col_idx,
-                message="'delimiter' is only valid for multi_select type.",
+                message="'delimiter' is only valid for field_type 'list'.",
             ))
 
-        # availability mappings should include parse_time_range rule (warning only)
-        if field_name == "availability":
-            has_parse_time_range = any(r.get("action") in PARSE_TIME_RANGE_ACTIONS for r in rules)
-            if not has_parse_time_range:
-                result.warnings.append(ValidationIssue(
-                    header=header,
-                    column_index=col_idx,
-                    message=(
-                        "This column is mapped to 'availability' but has no "
-                        "'parse_time_range' rule. Availability data will not be parsed during sync."
-                    ),
-                ))
+        # availability with value_type != "time_range" is a warning
+        if field_name == "availability" and field_type == "group" and value_type != "time_range":
+            result.warnings.append(ValidationIssue(
+                header=header,
+                column_index=col_idx,
+                message=(
+                    "This column is mapped to 'availability' with field_type 'group' but "
+                    "value_type is not 'time_range'. Availability data will not be parsed during sync."
+                ),
+            ))
 
         # ------------------------------------------------------------------
         # Per-rule checks
@@ -253,6 +269,18 @@ def validate_column_mappings(
             condition = rule.get("condition", "")
             match_str = rule.get("match")
             action = rule.get("action", "")
+
+            # Removed actions (parse_time_range / parse_availability) are errors
+            if action in _REMOVED_RULE_ACTIONS:
+                result.errors.append(ValidationIssue(
+                    header=header,
+                    column_index=col_idx,
+                    rule_index=i,
+                    message=(
+                        f"Rule action '{action}' is no longer valid. "
+                        "Use value_type='time_range' on the mapping instead."
+                    ),
+                ))
 
             # regex must compile
             if condition == "regex" and match_str:
@@ -300,17 +328,17 @@ def validate_column_mappings(
             if action == "set":
                 set_fired_at = i
 
-        # availability row_key should be parseable as a time range (warning only)
-        if field_name == "availability" and entry.get("row_key"):
-            row_key = entry["row_key"]
-            normalized = re.sub(r"\s+", " ", row_key.strip())
+        # availability group_key should be parseable as a time range (warning only)
+        if field_name == "availability" and field_type == "group" and entry.get("group_key"):
+            group_key = entry["group_key"]
+            normalized = re.sub(r"\s+", " ", group_key.strip())
             parts = normalized.split(" - ", 1)
             if len(parts) != 2:
                 result.warnings.append(ValidationIssue(
                     header=header,
                     column_index=col_idx,
                     message=(
-                        f"row_key '{row_key}' does not appear to be a valid time range "
+                        f"group_key '{group_key}' does not appear to be a valid time range "
                         "(expected format: 'H:MM AM - H:MM PM'). "
                         "Availability parsing may fail during sync."
                     ),

--- a/backend/app/services/sync_service.py
+++ b/backend/app/services/sync_service.py
@@ -3,7 +3,7 @@ Sync service — reads rows from a Google Sheet and upserts Users + Memberships.
 
 Flow per row:
   1. Apply parse rules to raw cell value (string transforms, in order)
-  2. Type-coerce the result
+  2. Type-coerce the result via value_type dispatch
   3. Upsert User by email
   4. Upsert Membership by (user_id, tournament_id)
   5. Return SyncResult summary
@@ -19,10 +19,9 @@ from sqlalchemy.orm import Session
 from app.models.models import Event, Membership, SheetConfig, Tournament, User
 from app.core.phone import format_phone_us
 from app.schemas.sheet_config import (
-    PARSE_TIME_RANGE_ACTIONS,
     SyncError,
     SyncResult,
-    coerce_legacy_type,
+    coerce_legacy_mapping,
     normalize_column_mappings_input,
 )
 from app.services.sheets_service import SheetsService
@@ -35,14 +34,14 @@ from app.services.sheets_service import SheetsService
 _USER_IDENTITY_FIELDS = frozenset({
     "first_name", "last_name", "email", "phone",
 })
- 
+
 # TODO(temp): written to Membership until user self-management is implemented
 _MEMBERSHIP_PROFILE_FIELDS = frozenset({
     "shirt_size", "dietary_restriction",
     "university", "major", "employer",
     "student_status", "competition_exp", "volunteering_exp",
 })
- 
+
 # Union — all fields that come from VOLUNTEER_KNOWN_FIELDS user-side hints
 _USER_FIELDS = _USER_IDENTITY_FIELDS | _MEMBERSHIP_PROFILE_FIELDS
 
@@ -97,11 +96,11 @@ def _parse_time(raw: str) -> str:
     return f"{h:02d}:{m:02d}"
 
 
-def _parse_time_range(row_key: str) -> tuple[str, str]:
-    normalized = re.sub(r"\s+", " ", row_key.strip())
+def _parse_time_range(group_key: str) -> tuple[str, str]:
+    normalized = re.sub(r"\s+", " ", group_key.strip())
     parts = normalized.split(" - ", 1)
     if len(parts) != 2:
-        raise ValueError(f"Cannot parse time range: '{row_key}'")
+        raise ValueError(f"Cannot parse time range: '{group_key}'")
     return _parse_time(parts[0]), _parse_time(parts[1])
 
 
@@ -164,13 +163,13 @@ def _parse_day_string(day_str: str, tournament: Tournament) -> str | None:
 
 def _parse_availability(
     cell_value: str,
-    row_key: str,
+    group_key: str,
     tournament: Tournament,
 ) -> list[dict]:
     if not cell_value or cell_value.strip().lower() == "none":
         return []
 
-    start_time, end_time = _parse_time_range(row_key)
+    start_time, end_time = _parse_time_range(group_key)
     slots = []
 
     for day_str in cell_value.split(","):
@@ -188,7 +187,7 @@ _TIME_RANGE_RE = re.compile(
 )
 
 
-def _extract_row_key_and_day_text(value: str) -> tuple[str, str]:
+def _extract_group_key_and_day_text(value: str) -> tuple[str, str]:
     """
     Extract "start - end" and the remaining day text from a value string.
 
@@ -201,9 +200,9 @@ def _extract_row_key_and_day_text(value: str) -> tuple[str, str]:
 
     start = m.group("start")
     end = m.group("end")
-    row_key = f"{start} - {end}"
+    group_key = f"{start} - {end}"
     day_text = (value[:m.start()] + value[m.end():]).strip(" ,;-")
-    return row_key, day_text
+    return group_key, day_text
 
 
 def _merge_availability(existing: list[dict], new_slots: list[dict]) -> list[dict]:
@@ -267,14 +266,13 @@ def _apply_rules(
     rules: list[dict],
     mapping: dict,
     tournament: Tournament,
-) -> str | list[dict] | None:
+) -> str | None:
     """
     Apply an ordered list of parse rules to a raw cell string.
 
     Returns:
-    - list[dict] — parse_time_range / parse_availability fired; skip type coercion
-    - None       — discard fired
-    - str        — transformed string; type coercion runs next
+    - None — discard fired
+    - str  — transformed string; value_type coercion runs next
     """
     current: str = value
 
@@ -290,18 +288,6 @@ def _apply_rules(
 
         if action == "discard":
             return None
-
-        # Both canonical (parse_time_range) and legacy alias (parse_availability)
-        if action in PARSE_TIME_RANGE_ACTIONS:
-            row_key = (mapping.get("row_key") or "").strip()
-            day_value = current
-
-            # Allow parse_time_range on non-matrix mappings by extracting
-            # the time range from the current value when row_key is absent.
-            if not row_key:
-                row_key, day_value = _extract_row_key_and_day_text(current)
-
-            return _parse_availability(day_value, row_key, tournament)
 
         if action == "set":
             current = rule_value
@@ -325,6 +311,45 @@ def _apply_rules(
             current = current + rule_value
 
     return current
+
+
+# ---------------------------------------------------------------------------
+# Value type coercion
+# ---------------------------------------------------------------------------
+
+def _coerce_value(value: str, value_type: str | None, field: str | None) -> Any:
+    """Coerce a post-rules string to the target value_type."""
+    if value_type == "text" or value_type is None:
+        parsed = value.strip() if value else None
+        if parsed is None:
+            return None
+        if field == "phone":
+            return format_phone_us(parsed)
+        return parsed
+
+    if value_type == "boolean":
+        v = value.strip().lower()
+        if v in ("yes", "true", "1"):
+            return True
+        if v in ("no", "false", "0"):
+            return False
+        return None
+
+    if value_type == "number":
+        try:
+            stripped = value.strip()
+            if "." in stripped:
+                return float(stripped)
+            return int(stripped)
+        except (ValueError, AttributeError):
+            return None
+
+    if value_type == "date":
+        stripped = value.strip() if value else None
+        return stripped or None
+
+    # time_range is handled at _process_cell level (needs group_key + tournament)
+    return value.strip() if value else None
 
 
 # ---------------------------------------------------------------------------
@@ -380,7 +405,11 @@ def _process_cell(
     mapping: dict,
     tournament: Tournament,
 ) -> Any:
-    field_type = coerce_legacy_type(mapping.get("type", "string"))
+    # Coerce legacy type/row_key fields so old in-memory mappings still work
+    mapping = coerce_legacy_mapping(mapping)
+
+    field_type = mapping.get("field_type", "single")
+    value_type = mapping.get("value_type")
 
     if field_type == "ignore":
         return None
@@ -389,47 +418,29 @@ def _process_cell(
     if rules:
         result = _apply_rules(value, rules, mapping, tournament)
 
-        if isinstance(result, list):
-            return result
-
         if result is None:
             return None
 
         value = result
 
-    if field_type == "string":
-        parsed = value.strip() if value else None
-        if parsed is None:
-            return None
-        if mapping.get("field") == "phone":
-            return format_phone_us(parsed)
-        return parsed
+    # value_type dispatch
+    if value_type == "time_range":
+        # Availability-style parsing: group_key is the time range string
+        group_key = (mapping.get("group_key") or "").strip()
+        day_value = value
 
-    if field_type == "boolean":
-        v = value.strip().lower()
-        if v in ("yes", "true", "1"):
-            return True
-        if v in ("no", "false", "0"):
-            return False
-        return None
+        if not group_key:
+            # Extract time range from the value itself when group_key absent
+            group_key, day_value = _extract_group_key_and_day_text(value)
 
-    if field_type == "integer":
-        try:
-            return int(value.strip())
-        except (ValueError, AttributeError):
-            return None
+        return _parse_availability(day_value, group_key, tournament)
 
-    if field_type == "multi_select":
+    if field_type == "list":
         if not value or not value.strip():
             return []
         delimiter = mapping.get("delimiter") or ","
         options = mapping.get("options")
         if options:
-            # Option-aware splitting: greedily match known options so commas
-            # inside option text (e.g. "Life, Personal & Social Science") are
-            # not treated as delimiters.
-            # options is list[str] (raw); derive aliases from is_alias rules so
-            # post-rules transformed values are matched correctly.
             rules_list = mapping.get("rules") or []
             alias_map = {
                 r["match"]: r["value"]
@@ -441,13 +452,20 @@ def _process_cell(
                 key=len,
                 reverse=True,
             )
-            return _split_multi_select_options(value, alias_options, delimiter)
-        return [v.strip() for v in value.split(delimiter) if v.strip()]
+            parts = _split_multi_select_options(value, alias_options, delimiter)
+        else:
+            parts = [v.strip() for v in value.split(delimiter) if v.strip()]
 
-    if field_type == "matrix_row":
-        return value.strip() if value else None
+        if value_type and value_type != "text":
+            return [_coerce_value(p, value_type, mapping.get("field")) for p in parts]
+        return parts
 
-    return value.strip() if value else None
+    if field_type == "group":
+        # Returns the coerced scalar; caller aggregates into a dict keyed by group_key
+        return _coerce_value(value, value_type, mapping.get("field"))
+
+    # field_type == "single"
+    return _coerce_value(value, value_type, mapping.get("field"))
 
 
 # ---------------------------------------------------------------------------
@@ -495,7 +513,7 @@ def sync_sheet(
             membership_fields: dict[str, Any] = {}
             availability_slots: list[dict] = []
             extra_data: dict[str, Any] = {}
-            event_pref_ranked: dict[str, str] = {}  # row_key → cell value for grid ranking
+            event_pref_ranked: dict[str, str] = {}  # group_key → cell value for grid ranking
 
             for mapping in mappings:
                 header = str(mapping.get("header", ""))
@@ -506,7 +524,10 @@ def sync_sheet(
                 raw_value = row[col_idx] if col_idx < len(row) else ""
 
                 field = mapping.get("field")
-                field_type = coerce_legacy_type(mapping.get("type", "string"))
+
+                # Coerce legacy type/row_key before dispatch
+                m = coerce_legacy_mapping(mapping)
+                field_type = m.get("field_type", "single")
 
                 if field_type == "ignore" or field == "__ignore__":
                     continue
@@ -527,12 +548,12 @@ def sync_sheet(
                         availability_slots.extend(processed)
 
                 elif field == "event_preference":
-                    if field_type == "matrix_row":
-                        # Grid-ranked event preference: row_key is the event name,
+                    if field_type == "group":
+                        # Grid-ranked event preference: group_key is the event name,
                         # cell value is the rank (e.g. "1st choice", "2nd choice")
-                        row_key = mapping.get("row_key", "")
-                        if processed and row_key:
-                            event_pref_ranked[row_key] = str(processed)
+                        group_key = m.get("group_key", "")
+                        if processed and group_key:
+                            event_pref_ranked[group_key] = str(processed)
                     elif processed is not None:
                         if isinstance(processed, str):
                             processed = [processed]
@@ -541,38 +562,38 @@ def sync_sheet(
                             processed if isinstance(processed, list) else [processed]
                         )
 
-                elif field == "extra_data" and field_type == "matrix_row":
-                    # matrix_row aggregation into extra_data.
-                    # When extra_key is set, nest under extra_data[extra_key][row_key].
-                    # Without extra_key, store flat at extra_data[row_key].
-                    row_key = (mapping.get("row_key") or "").strip() or _slug(header)
-                    extra_key = (mapping.get("extra_key") or "").strip()
+                elif field == "extra_data" and field_type == "group":
+                    # group aggregation into extra_data.
+                    # When extra_key is set, nest under extra_data[extra_key][group_key].
+                    # Without extra_key, store flat at extra_data[group_key].
+                    group_key = (m.get("group_key") or "").strip() or _slug(header)
+                    extra_key = (m.get("extra_key") or "").strip()
                     if extra_key:
                         if not isinstance(extra_data.get(extra_key), dict):
                             extra_data[extra_key] = {}
-                        extra_data[extra_key][row_key] = processed if processed is not None else ""
+                        extra_data[extra_key][group_key] = processed if processed is not None else ""
                     else:
-                        extra_data[row_key] = processed if processed is not None else ""
+                        extra_data[group_key] = processed if processed is not None else ""
 
-                elif field_type == "matrix_row" and field not in ("availability", "event_preference"):
-                    # Generic matrix aggregation: build a dict keyed by row_key.
+                elif field_type == "group" and field not in ("availability", "event_preference"):
+                    # Generic group aggregation: build a dict keyed by group_key.
                     # Blank cells store "" so all keys are always present.
-                    row_key = (mapping.get("row_key") or "").strip()
-                    if not row_key:
-                        row_key = _slug(header)
+                    group_key = (m.get("group_key") or "").strip()
+                    if not group_key:
+                        group_key = _slug(header)
                     if field not in membership_fields:
                         membership_fields[field] = {}
-                    membership_fields[field][row_key] = processed if processed is not None else ""
+                    membership_fields[field][group_key] = processed if processed is not None else ""
 
                 elif field == "extra_data":
-                    extra_key = mapping.get("extra_key")
+                    extra_key = m.get("extra_key")
                     if extra_key and processed is not None:
                         extra_data[extra_key] = processed
 
                 elif field in _USER_IDENTITY_FIELDS:
                     if processed is not None:
                         user_fields[field] = processed
-                
+
                 # TODO(temp): sync profile fields to membership instead of user
                 elif field in _MEMBERSHIP_PROFILE_FIELDS:
                     if processed is not None:
@@ -675,7 +696,7 @@ def sync_sheet(
 # ---------------------------------------------------------------------------
 
 def _slug(text: str) -> str:
-    """Slugify a header string for use as a fallback row_key."""
+    """Slugify a header string for use as a fallback group_key."""
     return re.sub(r"[^a-z0-9]+", "_", text.lower()).strip("_")[:50]
 
 

--- a/backend/tests/api/test_sheets.py
+++ b/backend/tests/api/test_sheets.py
@@ -99,21 +99,20 @@ def test_validate_mappings_returns_200_with_structured_errors(
     assert any("extra_key" in e["message"] for e in data["errors"])
 
 
-def test_validate_mappings_allows_parse_time_range_on_string_availability(
+def test_validate_mappings_availability_single_value_type_text(
     client, td_user, td_tournament
 ):
+    """Availability mapped as single/text (no time_range coercion) is valid but warns."""
     login(client, "td@test.com", "tdpass")
     response = client.post(
         f"/tournaments/{td_tournament.id}/sheets/configs/validate-mappings/",
         json={
             "column_mappings": {
-                "Email Address": {"field": "email", "type": "string"},
+                "Email Address": {"field": "email", "field_type": "single", "value_type": "text"},
                 "Will you be available for the full day?": {
                     "field": "availability",
-                    "type": "string",
-                    "rules": [
-                        {"condition": "always", "action": "parse_time_range"},
-                    ],
+                    "field_type": "single",
+                    "value_type": "text",
                 },
             }
         },

--- a/backend/tests/api/test_sync.py
+++ b/backend/tests/api/test_sync.py
@@ -14,24 +14,25 @@ NATS_BLOCKS = [
 ]
 
 COLUMN_MAPPINGS = {
-    "Timestamp":       {"field": "__ignore__",      "type": "ignore"},
-    "Email Address":   {"field": "email",            "type": "string"},
-    "First Name":      {"field": "first_name",       "type": "string"},
-    "Last Name":       {"field": "last_name",        "type": "string"},
-    "Phone Number":    {"field": "phone",            "type": "string"},
-    "T-Shirt Size":    {"field": "shirt_size",       "type": "string"},
-    "Role Preference": {"field": "role_preference",  "type": "multi_select"},
-    "Which events?":   {"field": "event_preference", "type": "string"},
+    "Timestamp":       {"field": "__ignore__",      "field_type": "ignore"},
+    "Email Address":   {"field": "email",            "field_type": "single", "value_type": "text"},
+    "First Name":      {"field": "first_name",       "field_type": "single", "value_type": "text"},
+    "Last Name":       {"field": "last_name",        "field_type": "single", "value_type": "text"},
+    "Phone Number":    {"field": "phone",            "field_type": "single", "value_type": "text"},
+    "T-Shirt Size":    {"field": "shirt_size",       "field_type": "single", "value_type": "text"},
+    "Role Preference": {"field": "role_preference",  "field_type": "list",   "value_type": "text"},
+    "Which events?":   {"field": "event_preference", "field_type": "single", "value_type": "text"},
     "Availability [8:00 AM - 10:00 AM]": {
-        "field": "availability", "type": "matrix_row", "row_key": "8:00 AM - 10:00 AM",
-        "rules": [{"condition": "always", "action": "parse_time_range"}],
+        "field": "availability", "field_type": "group", "value_type": "time_range",
+        "group_key": "8:00 AM - 10:00 AM",
     },
     "Availability [10:00 AM - NOON]": {
-        "field": "availability", "type": "matrix_row", "row_key": "10:00 AM - NOON",
-        "rules": [{"condition": "always", "action": "parse_time_range"}],
+        "field": "availability", "field_type": "group", "value_type": "time_range",
+        "group_key": "10:00 AM - NOON",
     },
     "Transportation": {
-        "field": "extra_data", "type": "string", "extra_key": "transportation",
+        "field": "extra_data", "field_type": "single", "value_type": "text",
+        "extra_key": "transportation",
     },
 }
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -34,7 +34,6 @@ from app.models.models import Membership, Tournament, User
 from app.schemas.sheet_config import (
     FormQuestionOption,
     MappedHeader,
-    ParseRule,
     SheetHeadersResponse,
     SheetValidateResponse,
 )
@@ -231,18 +230,18 @@ def _make_mock_sheets_service() -> MagicMock:
         sheet_name="Form Responses 1",
         sheet_type="volunteers",
         mappings=[
-            MappedHeader(header="Timestamp",     field="__ignore__", type="ignore"),
-            MappedHeader(header="Email Address", field="email",      type="string"),
-            MappedHeader(header="First Name",    field="first_name", type="string"),
-            MappedHeader(header="Last Name",     field="last_name",  type="string"),
-            MappedHeader(header="Phone Number",  field="phone",      type="string"),
-            MappedHeader(header="T-Shirt Size",  field="shirt_size", type="string"),
+            MappedHeader(header="Timestamp",     field="__ignore__", field_type="ignore"),
+            MappedHeader(header="Email Address", field="email",      field_type="single", value_type="text"),
+            MappedHeader(header="First Name",    field="first_name", field_type="single", value_type="text"),
+            MappedHeader(header="Last Name",     field="last_name",  field_type="single", value_type="text"),
+            MappedHeader(header="Phone Number",  field="phone",      field_type="single", value_type="text"),
+            MappedHeader(header="T-Shirt Size",  field="shirt_size", field_type="single", value_type="text"),
             MappedHeader(
                 header="Availability [8:00 AM - 10:00 AM]",
                 field="availability",
-                type="matrix_row",
-                row_key="8:00 AM - 10:00 AM",
-                rules=[ParseRule(condition="always", action="parse_time_range")],
+                field_type="group",
+                value_type="time_range",
+                group_key="8:00 AM - 10:00 AM",
             ),
         ],
     )

--- a/backend/tests/services/test_sheets_service.py
+++ b/backend/tests/services/test_sheets_service.py
@@ -24,7 +24,6 @@ from app.services.volunteer_hints import (
 from app.schemas.sheet_config import (
     FormQuestionOption,
     MappedHeader,
-    PARSE_TIME_RANGE_ACTIONS,
 )
 
 FAKE_URL = "https://docs.google.com/spreadsheets/d/abc123/edit"
@@ -68,63 +67,64 @@ def test_extract_spreadsheet_id_invalid(svc: SheetsService):
 # ---------------------------------------------------------------------------
 # get_headers — flat mappings list, no form questions
 #
-# Without form data, hints predict field only; type always defaults to "string"
-# except for availability bracket pattern → "matrix_row".
+# Without form data, hints predict field only; field_type always defaults to
+# "single"/"text" except for availability bracket pattern → "group"/"time_range".
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("header,expected_field,expected_type,expected_row_key", [
+@pytest.mark.parametrize("header,expected_field,expected_field_type,expected_value_type,expected_group_key", [
     # Identity
-    ("Email Address",        "email",               "string",       None),
-    ("email",                "email",               "string",       None),
-    ("First Name",           "first_name",          "string",       None),
-    ("Last Name",            "last_name",           "string",       None),
-    ("First & Last Name",    "full_name",           "string",       None),
-    ("Phone Number",         "phone",               "string",       None),
-    ("T-Shirt Size",         "shirt_size",          "string",       None),
-    ("Dietary Restrictions", "dietary_restriction",  "string",       None),
+    ("Email Address",        "email",               "single", "text",       None),
+    ("email",                "email",               "single", "text",       None),
+    ("First Name",           "first_name",          "single", "text",       None),
+    ("Last Name",            "last_name",            "single", "text",       None),
+    ("First & Last Name",    "full_name",            "single", "text",       None),
+    ("Phone Number",         "phone",               "single", "text",       None),
+    ("T-Shirt Size",         "shirt_size",          "single", "text",       None),
+    ("Dietary Restrictions", "dietary_restriction",  "single", "text",       None),
     # New user fields
     ("If you are a college student, what year are you in?",
-                             "student_status",       "string",       None),
-    ("I am a ...",           "student_status",       "string",       None),
+                             "student_status",       "single", "text",       None),
+    ("I am a ...",           "student_status",       "single", "text",       None),
     ("Have you competed in Science Olympiad in the past?",
-                             "competition_exp",      "string",       None),
+                             "competition_exp",      "single", "text",       None),
     ("Have you volunteered for past Science Olympiad competitions?",
-                             "volunteering_exp",     "string",       None),
-    # Role & preference — type defaults to "string" without form data
-    ("Volunteering Role Preference", "role_preference",  "string", None),
-    ("Event Preference",             "event_preference", "string", None),
+                             "volunteering_exp",     "single", "text",       None),
+    # Role & preference — field_type defaults to "single"/"text" without form data
+    ("Volunteering Role Preference", "role_preference",  "single", "text", None),
+    ("Event Preference",             "event_preference", "single", "text", None),
     # Lunch
     ("Which protein do you want in your Chipotle burrito?",
-                             "lunch_order",          "string",       None),
+                             "lunch_order",          "single", "text",       None),
     ("What would you like to drink?",
-                             "lunch_order",          "string",       None),
-    ("Lunch Order",          "lunch_order",          "string",       None),
+                             "lunch_order",          "single", "text",       None),
+    ("Lunch Order",          "lunch_order",          "single", "text",       None),
     # Notes
-    ("Additional Notes",     "notes",               "string",       None),
+    ("Additional Notes",     "notes",               "single", "text",       None),
     # Extra data with keys
-    ("Where are you coming from?",  "extra_data",   "string",       None),
+    ("Where are you coming from?",  "extra_data",   "single", "text",       None),
     ("Do you have any potential conflict of interests?",
-                             "extra_data",           "string",       None),
+                             "extra_data",           "single", "text",       None),
     # Ignore
-    ("Timestamp",            "__ignore__",          "ignore",       None),
-    ("How did you hear about us?", "__ignore__",    "ignore",       None),
-    ("Some Random Column",   "__ignore__",          "ignore",       None),
-    # Availability matrix rows — bracket pattern forces matrix_row
+    ("Timestamp",            "__ignore__",          "ignore", None,          None),
+    ("How did you hear about us?", "__ignore__",    "ignore", None,          None),
+    ("Some Random Column",   "__ignore__",          "ignore", None,          None),
+    # Availability matrix rows — bracket pattern forces group/time_range
     ("Availability [8:00 AM - 10:00 AM]",
-        "availability", "matrix_row", "8:00 AM - 10:00 AM"),
+        "availability", "group", "time_range", "8:00 AM - 10:00 AM"),
     ("Availability from 5/21 to 5/23 [8:00 AM  - 10:00 AM]",
-        "availability", "matrix_row", "8:00 AM  - 10:00 AM"),
+        "availability", "group", "time_range", "8:00 AM  - 10:00 AM"),
     ("Availability from 5/21 to 5/23 [10:00 AM  -  NOON]",
-        "availability", "matrix_row", "10:00 AM  -  NOON"),
+        "availability", "group", "time_range", "10:00 AM  -  NOON"),
 ])
-def test_hint_detection(svc, header, expected_field, expected_type, expected_row_key):
+def test_hint_detection(svc, header, expected_field, expected_field_type, expected_value_type, expected_group_key):
     """Hint-based detection via get_headers with no form questions."""
     _mock_headers(svc, [header])
     result = svc.get_headers(FAKE_URL, "Sheet1", sheet_type="volunteers")
     m = _by_header(result, header)
     assert m.field == expected_field
-    assert m.type == expected_type
-    assert m.row_key == expected_row_key
+    assert m.field_type == expected_field_type
+    assert m.value_type == expected_value_type
+    assert m.group_key == expected_group_key
 
 
 def test_get_headers_returns_mappings_list(svc: SheetsService):
@@ -136,7 +136,7 @@ def test_get_headers_returns_mappings_list(svc: SheetsService):
     assert all(isinstance(m, MappedHeader) for m in result.mappings)
     assert _by_header(result, "Email Address").field == "email"
     assert _by_header(result, "First Name").field == "first_name"
-    assert _by_header(result, "Timestamp").type == "ignore"
+    assert _by_header(result, "Timestamp").field_type == "ignore"
 
 
 def test_get_headers_preserves_column_order(svc: SheetsService):
@@ -151,6 +151,17 @@ def test_get_headers_events_sheet_scopes_known_fields(svc: SheetsService):
     result = svc.get_headers(FAKE_URL, "Sheet1", sheet_type="events")
     assert result.sheet_type == "events"
     assert "email" not in result.known_fields
+
+
+def test_get_headers_response_includes_valid_field_types(svc: SheetsService):
+    """Response includes valid_field_types and valid_value_types (not old valid_types)."""
+    _mock_headers(svc, ["Email Address"])
+    result = svc.get_headers(FAKE_URL, "Sheet1", sheet_type="volunteers")
+    assert hasattr(result, "valid_field_types")
+    assert hasattr(result, "valid_value_types")
+    assert "single" in result.valid_field_types
+    assert "group" in result.valid_field_types
+    assert "time_range" in result.valid_value_types
 
 
 # ---------------------------------------------------------------------------
@@ -196,10 +207,10 @@ def test_dedup_second_email_becomes_ignore(svc: SheetsService):
     second = _by_header(result, "email")
     assert first.field == "email"
     assert second.field == "__ignore__"
-    assert second.type == "ignore"
+    assert second.field_type == "ignore"
 
 
-def test_dedup_availability_allows_multiple_matrix_rows(svc: SheetsService):
+def test_dedup_availability_allows_multiple_group_rows(svc: SheetsService):
     """Multiple availability columns are all allowed — availability is exempt from dedup."""
     _mock_headers(svc, [
         "Availability [8:00 AM - 10:00 AM]",
@@ -209,11 +220,12 @@ def test_dedup_availability_allows_multiple_matrix_rows(svc: SheetsService):
     result = svc.get_headers(FAKE_URL, "Sheet1", sheet_type="volunteers")
     for m in result.mappings:
         assert m.field == "availability"
-        assert m.type == "matrix_row"
+        assert m.field_type == "group"
+        assert m.value_type == "time_range"
 
 
-def test_multi_lunch_upgrades_to_matrix_row(svc: SheetsService):
-    """Two lunch-related columns are upgraded to matrix_row with inferred row_keys."""
+def test_multi_lunch_upgrades_to_group(svc: SheetsService):
+    """Two lunch-related columns are upgraded to group with inferred group_keys."""
     _mock_headers(svc, [
         "Which protein do you want?",
         "What would you like to drink?",
@@ -222,15 +234,16 @@ def test_multi_lunch_upgrades_to_matrix_row(svc: SheetsService):
     first = result.mappings[0]
     second = result.mappings[1]
     assert first.field == "lunch_order"
-    assert first.type == "matrix_row"
-    assert first.row_key == "protein"
+    assert first.field_type == "group"
+    assert first.value_type == "text"
+    assert first.group_key == "protein"
     assert second.field == "lunch_order"
-    assert second.type == "matrix_row"
-    assert second.row_key == "drink"
+    assert second.field_type == "group"
+    assert second.group_key == "drink"
 
 
 def test_multi_lunch_includes_options_from_form_questions(svc: SheetsService):
-    """Multi-lunch matrix_row headers include options when form questions are provided."""
+    """Multi-lunch group headers include options when form questions are provided."""
     protein_header = "Which protein do you want in your Chipotle burrito?"
     drink_header = "What would you like to drink?"
     questions = [
@@ -253,14 +266,15 @@ def test_multi_lunch_includes_options_from_form_questions(svc: SheetsService):
     assert [o.raw for o in drink.options] == ["Water", "Lemonade"]
 
 
-def test_single_lunch_stays_string(svc: SheetsService):
-    """A single lunch header stays as string — no upgrade."""
+def test_single_lunch_stays_single(svc: SheetsService):
+    """A single lunch header stays as single — no upgrade."""
     _mock_headers(svc, ["Lunch Order"])
     result = svc.get_headers(FAKE_URL, "Sheet1", sheet_type="volunteers")
     m = result.mappings[0]
     assert m.field == "lunch_order"
-    assert m.type == "string"
-    assert m.row_key is None
+    assert m.field_type == "single"
+    assert m.value_type == "text"
+    assert m.group_key is None
 
 
 def test_dedup_extra_key_collision_becomes_ignore(svc: SheetsService):
@@ -275,16 +289,19 @@ def test_dedup_extra_key_collision_becomes_ignore(svc: SheetsService):
 
 
 # ---------------------------------------------------------------------------
-# get_headers — parse_time_range auto-attachment
+# get_headers — availability group auto-configuration (no parse_time_range rule)
 # ---------------------------------------------------------------------------
 
-def test_hint_availability_gets_parse_time_range(svc: SheetsService):
-    """Hint-matched availability rows get parse_time_range rule auto-attached."""
+def test_hint_availability_gets_time_range_value_type(svc: SheetsService):
+    """Hint-matched availability rows get value_type='time_range' (no rule needed)."""
     _mock_headers(svc, ["Availability [8:00 AM - 10:00 AM]"])
     result = svc.get_headers(FAKE_URL, "Sheet1", sheet_type="volunteers")
     m = _by_header(result, "Availability [8:00 AM - 10:00 AM]")
-    assert m.rules is not None
-    assert any(r.action in PARSE_TIME_RANGE_ACTIONS for r in m.rules)
+    assert m.field_type == "group"
+    assert m.value_type == "time_range"
+    assert m.group_key == "8:00 AM - 10:00 AM"
+    # No parse_time_range rule — time_range is now expressed via value_type
+    assert m.rules is None
 
 
 # ---------------------------------------------------------------------------
@@ -317,8 +334,8 @@ def _make_dropdown_q(qid: str, title: str, options: list[FormQuestionOption]) ->
 
 
 def test_form_question_type_takes_priority(svc: SheetsService):
-    """Form question nexus_type overrides default string type.
-    Checkbox → multi_select even though hint alone would give string.
+    """Form question nexus_type overrides default single/text.
+    Checkbox → list/text even though hint alone would give single/text.
     """
     header = "If interested in event volunteering, which event(s) would you prefer helping with?"
     questions = [_make_checkbox_q(
@@ -332,15 +349,16 @@ def test_form_question_type_takes_priority(svc: SheetsService):
     _mock_headers(svc, [header])
     result = svc.get_headers(FAKE_URL, "Sheet1", sheet_type="volunteers", form_questions=questions)
     m = _by_header(result, header)
-    assert m.type == "multi_select"
+    assert m.field_type == "list"
+    assert m.value_type == "text"
     assert m.field == "event_preference"
     assert m.rules is not None
     assert any(r.action == "replace" and r.match == "Anatomy - Study body" for r in m.rules)
     assert not any(r.match == "Chemistry Lab" for r in m.rules)
 
 
-def test_form_radio_maps_to_string(svc: SheetsService):
-    """RADIO / MULTIPLE_CHOICE form type → string (single selection)."""
+def test_form_radio_maps_to_single(svc: SheetsService):
+    """RADIO / MULTIPLE_CHOICE form type → single/text (single selection)."""
     header = "I am a ..."
     questions = [_make_radio_q("q1", "I am a ...", [
         FormQuestionOption(raw="UCI Undergraduate student", alias="UCI Undergraduate student"),
@@ -349,12 +367,13 @@ def test_form_radio_maps_to_string(svc: SheetsService):
     _mock_headers(svc, [header])
     result = svc.get_headers(FAKE_URL, "Sheet1", sheet_type="volunteers", form_questions=questions)
     m = _by_header(result, header)
-    assert m.type == "string"
+    assert m.field_type == "single"
+    assert m.value_type == "text"
     assert m.field == "student_status"
 
 
-def test_form_dropdown_maps_to_string(svc: SheetsService):
-    """DROP_DOWN form type → string."""
+def test_form_dropdown_maps_to_single(svc: SheetsService):
+    """DROP_DOWN form type → single/text."""
     header = "Current employer or university:"
     questions = [_make_dropdown_q("q1", "Current employer or university:", [
         FormQuestionOption(raw="USC", alias="USC"),
@@ -363,12 +382,13 @@ def test_form_dropdown_maps_to_string(svc: SheetsService):
     _mock_headers(svc, [header])
     result = svc.get_headers(FAKE_URL, "Sheet1", sheet_type="volunteers", form_questions=questions)
     m = _by_header(result, header)
-    assert m.type == "string"
+    assert m.field_type == "single"
+    assert m.value_type == "text"
     assert m.field == "employer"
 
 
-def test_form_availability_grid_gets_parse_time_range(svc: SheetsService):
-    """Availability grid question columns get matrix_row type, row_key, and parse_time_range rule."""
+def test_form_availability_grid_gets_time_range(svc: SheetsService):
+    """Availability grid question columns get group/time_range and group_key (no rule)."""
     _mock_headers(svc, [
         "Availability [8:00 AM - 10:00 AM]",
         "Availability [10:00 AM - 12:00 PM]",
@@ -384,15 +404,16 @@ def test_form_availability_grid_gets_parse_time_range(svc: SheetsService):
         ("Availability [10:00 AM - 12:00 PM]", "10:00 AM - 12:00 PM"),
     ]:
         m = _by_header(result, header)
-        assert m.type == "matrix_row"
+        assert m.field_type == "group"
+        assert m.value_type == "time_range"
         assert m.field == "availability"
-        assert m.row_key == expected_key
-        assert m.rules is not None
-        assert any(r.action in PARSE_TIME_RANGE_ACTIONS for r in m.rules)
+        assert m.group_key == expected_key
+        # No parse_time_range rule — handled by value_type
+        assert m.rules is None
 
 
-def test_form_event_preference_grid_no_parse_time_range(svc: SheetsService):
-    """Event preference grid columns get matrix_row type but NO parse_time_range rule."""
+def test_form_event_preference_grid_no_time_range(svc: SheetsService):
+    """Event preference grid columns get group/text type (not time_range)."""
     _mock_headers(svc, [
         "Please select the top 3 events [Anatomy and Physiology (B/C)]",
         "Please select the top 3 events [Forensics (C)]",
@@ -404,11 +425,9 @@ def test_form_event_preference_grid_no_parse_time_range(svc: SheetsService):
     )]
     result = svc.get_headers(FAKE_URL, "Sheet1", sheet_type="volunteers", form_questions=questions)
     for m in result.mappings:
-        assert m.type == "matrix_row"
+        assert m.field_type == "group"
+        assert m.value_type == "text"
         assert m.field == "event_preference"
-        # Should NOT have parse_time_range rule
-        if m.rules:
-            assert not any(r.action in PARSE_TIME_RANGE_ACTIONS for r in m.rules)
 
 
 def test_form_event_preference_grid_with_major_keyword_still_maps_event_preference(svc: SheetsService):
@@ -432,10 +451,8 @@ def test_form_event_preference_grid_with_major_keyword_still_maps_event_preferen
 
     result = svc.get_headers(FAKE_URL, "Sheet1", sheet_type="volunteers", form_questions=questions)
     for m in result.mappings:
-        assert m.type == "matrix_row"
+        assert m.field_type == "group"
         assert m.field == "event_preference"
-        if m.rules:
-            assert not any(r.action in PARSE_TIME_RANGE_ACTIONS for r in m.rules)
 
 
 def test_form_no_google_type_on_mapped_header(svc: SheetsService):
@@ -453,7 +470,7 @@ def test_unmatched_column_falls_back_to_hint(svc: SheetsService):
     questions = [_make_text_q("q1", "Email Address")]
     result = svc.get_headers(FAKE_URL, "Sheet1", sheet_type="volunteers", form_questions=questions)
     assert _by_header(result, "Email Address").field == "email"
-    assert _by_header(result, "Some Unknown Column").type == "ignore"
+    assert _by_header(result, "Some Unknown Column").field_type == "ignore"
 
 
 def test_form_dedup_second_email_becomes_ignore(svc: SheetsService):
@@ -657,7 +674,7 @@ def test_slugify(title, expected):
 def test_dedup_claims_field_on_first_use():
     claimed_fields: set = set()
     claimed_keys: set = set()
-    f, t, k = _dedup("email", "string", None, claimed_fields, claimed_keys)
+    f, ft, k = _dedup("email", "single", None, claimed_fields, claimed_keys)
     assert f == "email"
     assert "email" in claimed_fields
 
@@ -665,9 +682,9 @@ def test_dedup_claims_field_on_first_use():
 def test_dedup_second_use_falls_back():
     claimed_fields = {"email"}
     claimed_keys: set = set()
-    f, t, k = _dedup("email", "string", None, claimed_fields, claimed_keys)
+    f, ft, k = _dedup("email", "single", None, claimed_fields, claimed_keys)
     assert f == "__ignore__"
-    assert t == "ignore"
+    assert ft == "ignore"
 
 
 def test_dedup_ignore_never_claimed():
@@ -681,8 +698,8 @@ def test_dedup_ignore_never_claimed():
 def test_dedup_availability_never_claimed():
     claimed_fields: set = set()
     claimed_keys: set = set()
-    _dedup("availability", "matrix_row", None, claimed_fields, claimed_keys)
-    _dedup("availability", "matrix_row", None, claimed_fields, claimed_keys)
+    _dedup("availability", "group", None, claimed_fields, claimed_keys)
+    _dedup("availability", "group", None, claimed_fields, claimed_keys)
     assert "availability" not in claimed_fields
 
 
@@ -690,8 +707,8 @@ def test_dedup_event_preference_never_claimed():
     """event_preference allows multiple entries (grid rows)."""
     claimed_fields: set = set()
     claimed_keys: set = set()
-    _dedup("event_preference", "matrix_row", None, claimed_fields, claimed_keys)
-    f, t, _ = _dedup("event_preference", "matrix_row", None, claimed_fields, claimed_keys)
+    _dedup("event_preference", "group", None, claimed_fields, claimed_keys)
+    f, ft, _ = _dedup("event_preference", "group", None, claimed_fields, claimed_keys)
     assert f == "event_preference"
     assert "event_preference" not in claimed_fields
 
@@ -699,19 +716,19 @@ def test_dedup_event_preference_never_claimed():
 def test_dedup_extra_key_collision():
     claimed_fields: set = set()
     claimed_keys: set = set()
-    f1, _, _ = _dedup("extra_data", "string", "my_key", claimed_fields, claimed_keys)
-    f2, t2, _ = _dedup("extra_data", "string", "my_key", claimed_fields, claimed_keys)
+    f1, _, _ = _dedup("extra_data", "single", "my_key", claimed_fields, claimed_keys)
+    f2, ft2, _ = _dedup("extra_data", "single", "my_key", claimed_fields, claimed_keys)
     assert f1 == "extra_data"
     assert f2 == "__ignore__"
-    assert t2 == "ignore"
+    assert ft2 == "ignore"
 
 
-def test_dedup_any_matrix_row_field_never_claimed():
-    """Any field with type=matrix_row is exempt from claiming — not just availability/event_preference."""
+def test_dedup_any_group_field_never_claimed():
+    """Any field with field_type=group is exempt from claiming."""
     claimed_fields: set = set()
     claimed_keys: set = set()
-    f1, _, _ = _dedup("lunch_order", "matrix_row", None, claimed_fields, claimed_keys)
-    f2, _, _ = _dedup("lunch_order", "matrix_row", None, claimed_fields, claimed_keys)
+    f1, _, _ = _dedup("lunch_order", "group", None, claimed_fields, claimed_keys)
+    f2, _, _ = _dedup("lunch_order", "group", None, claimed_fields, claimed_keys)
     assert f1 == "lunch_order"
     assert f2 == "lunch_order"
     assert "lunch_order" not in claimed_fields

--- a/backend/tests/services/test_sheets_validation.py
+++ b/backend/tests/services/test_sheets_validation.py
@@ -10,9 +10,9 @@ from app.services.sheets_validation import validate_column_mappings
 def _base_mappings(**overrides):
     """Minimal valid mappings — email mapped, no other required fields."""
     m = {
-        "Email Address": {"field": "email", "type": "string"},
-        "First Name":    {"field": "first_name", "type": "string"},
-        "Last Name":     {"field": "last_name",  "type": "string"},
+        "Email Address": {"field": "email", "field_type": "single", "value_type": "text"},
+        "First Name":    {"field": "first_name", "field_type": "single", "value_type": "text"},
+        "Last Name":     {"field": "last_name",  "field_type": "single", "value_type": "text"},
     }
     m.update(overrides)
     return m
@@ -49,7 +49,7 @@ def test_valid_mappings_no_errors():
 
 def test_missing_email_is_error():
     result = validate_column_mappings({
-        "First Name": {"field": "first_name", "type": "string"},
+        "First Name": {"field": "first_name", "field_type": "single", "value_type": "text"},
     })
     assert not result.ok
     assert any("email" in e.message.lower() for e in result.errors)
@@ -57,34 +57,49 @@ def test_missing_email_is_error():
 def test_missing_email_header_is_none():
     """Config-level errors that don't belong to a specific header use None."""
     result = validate_column_mappings({
-        "First Name": {"field": "first_name", "type": "string"},
+        "First Name": {"field": "first_name", "field_type": "single", "value_type": "text"},
     })
     email_error = next(e for e in result.errors if "email" in e.message.lower() and "No column" in e.message)
     assert email_error.header is None
 
-def test_email_wrong_type_is_error():
+def test_email_wrong_field_type_is_error():
     result = validate_column_mappings(_base_mappings(**{
-        "Email Address": {"field": "email", "type": "boolean"},
+        "Email Address": {"field": "email", "field_type": "list", "value_type": "text"},
     }))
     assert not result.ok
-    assert any("email" in e.message.lower() and "string" in e.message.lower()
-               for e in result.errors)
+    assert any("email" in e.message.lower() for e in result.errors)
+
+def test_email_wrong_value_type_is_error():
+    result = validate_column_mappings(_base_mappings(**{
+        "Email Address": {"field": "email", "field_type": "single", "value_type": "boolean"},
+    }))
+    assert not result.ok
+    assert any("email" in e.message.lower() for e in result.errors)
 
 def test_multiple_email_mappings_is_error():
     result = validate_column_mappings({
-        "Email Address": {"field": "email", "type": "string"},
-        "Email (2)":     {"field": "email", "type": "string"},
+        "Email Address": {"field": "email", "field_type": "single", "value_type": "text"},
+        "Email (2)":     {"field": "email", "field_type": "single", "value_type": "text"},
     })
     assert not result.ok
     assert any("multiple" in e.message.lower() for e in result.errors)
 
 def test_ignored_email_column_not_counted():
-    """An email column typed as ignore doesn't satisfy the email requirement."""
+    """An email column with field_type=ignore doesn't satisfy the email requirement."""
     result = validate_column_mappings({
-        "Email Address": {"field": "__ignore__", "type": "ignore"},
+        "Email Address": {"field": "__ignore__", "field_type": "ignore"},
     })
     assert not result.ok
     assert any("email" in e.message.lower() for e in result.errors)
+
+def test_legacy_type_coerced_in_validation():
+    """Mappings using old `type` field are coerced before validation."""
+    result = validate_column_mappings({
+        "Email Address": {"field": "email", "type": "string"},
+        "First Name":    {"field": "first_name", "type": "string"},
+        "Last Name":     {"field": "last_name",  "type": "string"},
+    })
+    assert result.ok
 
 
 # ---------------------------------------------------------------------------
@@ -93,8 +108,8 @@ def test_ignored_email_column_not_counted():
 
 def test_duplicate_extra_key_is_error():
     result = validate_column_mappings(_base_mappings(**{
-        "Transport Q1": {"field": "extra_data", "type": "string", "extra_key": "transportation"},
-        "Transport Q2": {"field": "extra_data", "type": "string", "extra_key": "transportation"},
+        "Transport Q1": {"field": "extra_data", "field_type": "single", "value_type": "text", "extra_key": "transportation"},
+        "Transport Q2": {"field": "extra_data", "field_type": "single", "value_type": "text", "extra_key": "transportation"},
     }))
     assert not result.ok
     assert any("transportation" in e.message for e in result.errors)
@@ -102,8 +117,8 @@ def test_duplicate_extra_key_is_error():
 def test_duplicate_extra_key_header_is_list():
     """Duplicate extra_key errors must carry header as list[str], not a joined string."""
     result = validate_column_mappings(_base_mappings(**{
-        "Transport Q1": {"field": "extra_data", "type": "string", "extra_key": "transportation"},
-        "Transport Q2": {"field": "extra_data", "type": "string", "extra_key": "transportation"},
+        "Transport Q1": {"field": "extra_data", "field_type": "single", "value_type": "text", "extra_key": "transportation"},
+        "Transport Q2": {"field": "extra_data", "field_type": "single", "value_type": "text", "extra_key": "transportation"},
     }))
     dup_error = next(e for e in result.errors if "transportation" in e.message)
     assert isinstance(dup_error.header, list), (
@@ -115,8 +130,8 @@ def test_duplicate_extra_key_header_is_list():
 def test_duplicate_extra_key_header_list_serialised_in_response():
     """to_response_dict must serialise list headers as lists (not joined strings)."""
     result = validate_column_mappings(_base_mappings(**{
-        "Transport Q1": {"field": "extra_data", "type": "string", "extra_key": "transportation"},
-        "Transport Q2": {"field": "extra_data", "type": "string", "extra_key": "transportation"},
+        "Transport Q1": {"field": "extra_data", "field_type": "single", "value_type": "text", "extra_key": "transportation"},
+        "Transport Q2": {"field": "extra_data", "field_type": "single", "value_type": "text", "extra_key": "transportation"},
     }))
     response = result.to_response_dict()
     dup_error = next(e for e in response["errors"] if "transportation" in e["message"])
@@ -128,8 +143,8 @@ def test_duplicate_extra_key_header_with_commas_in_name():
     h1 = "Have you competed in Science Olympiad in the past?"
     h2 = "If you have competed, please list events"  # contains a comma
     result = validate_column_mappings(_base_mappings(**{
-        h1: {"field": "extra_data", "type": "string", "extra_key": "scioly_competed"},
-        h2: {"field": "extra_data", "type": "string", "extra_key": "scioly_competed"},
+        h1: {"field": "extra_data", "field_type": "single", "value_type": "text", "extra_key": "scioly_competed"},
+        h2: {"field": "extra_data", "field_type": "single", "value_type": "text", "extra_key": "scioly_competed"},
     }))
     dup_error = next(e for e in result.errors if "scioly_competed" in e.message)
     assert isinstance(dup_error.header, list)
@@ -138,55 +153,55 @@ def test_duplicate_extra_key_header_with_commas_in_name():
 
 def test_different_extra_keys_ok():
     result = validate_column_mappings(_base_mappings(**{
-        "Transport": {"field": "extra_data", "type": "string", "extra_key": "transportation"},
-        "Carpool":   {"field": "extra_data", "type": "integer", "extra_key": "carpool_seats"},
+        "Transport": {"field": "extra_data", "field_type": "single", "value_type": "text", "extra_key": "transportation"},
+        "Carpool":   {"field": "extra_data", "field_type": "single", "value_type": "number", "extra_key": "carpool_seats"},
     }))
     assert result.ok
 
-def test_matrix_row_with_same_extra_key_not_duplicate_error():
-    """matrix_row columns sharing an extra_key do not overwrite — no duplicate extra_key error."""
+def test_group_with_same_extra_key_not_duplicate_error():
+    """group columns sharing an extra_key do not overwrite — no duplicate extra_key error."""
     result = validate_column_mappings(_base_mappings(**{
-        "Which protein?": {"field": "lunch_order", "type": "matrix_row", "row_key": "protein"},
-        "Drink choice":   {"field": "lunch_order", "type": "matrix_row", "row_key": "drink"},
+        "Which protein?": {"field": "lunch_order", "field_type": "group", "value_type": "text", "group_key": "protein"},
+        "Drink choice":   {"field": "lunch_order", "field_type": "group", "value_type": "text", "group_key": "drink"},
     }))
     assert not any("Duplicate extra_key" in e.message for e in result.errors)
 
-def test_duplicate_row_key_same_field_is_error():
-    """Two matrix_row columns with the same field and row_key DO overwrite — error."""
+def test_duplicate_group_key_same_field_is_error():
+    """Two group columns with the same field and group_key DO overwrite — error."""
     result = validate_column_mappings(_base_mappings(**{
-        "Lunch col 1": {"field": "lunch_order", "type": "matrix_row", "row_key": "protein"},
-        "Lunch col 2": {"field": "lunch_order", "type": "matrix_row", "row_key": "protein"},
+        "Lunch col 1": {"field": "lunch_order", "field_type": "group", "value_type": "text", "group_key": "protein"},
+        "Lunch col 2": {"field": "lunch_order", "field_type": "group", "value_type": "text", "group_key": "protein"},
     }))
     assert not result.ok
-    assert any("Duplicate row_key" in e.message and "protein" in e.message for e in result.errors)
+    assert any("Duplicate group_key" in e.message and "protein" in e.message for e in result.errors)
 
-def test_duplicate_row_key_different_fields_ok():
-    """Same row_key across different fields is fine — they write to separate buckets."""
+def test_duplicate_group_key_different_fields_ok():
+    """Same group_key across different fields is fine — they write to separate buckets."""
     result = validate_column_mappings(_base_mappings(**{
-        "Avail morning":    {"field": "availability",  "type": "matrix_row", "row_key": "morning",
-                             "rules": [{"condition": "always", "action": "parse_time_range"}]},
-        "Pref morning":     {"field": "event_preference", "type": "matrix_row", "row_key": "morning"},
+        "Avail morning":    {"field": "availability",  "field_type": "group", "value_type": "time_range",
+                             "group_key": "8:00 AM - 10:00 AM"},
+        "Pref morning":     {"field": "event_preference", "field_type": "group", "value_type": "text",
+                             "group_key": "morning"},
     }))
-    assert not any("Duplicate row_key" in e.message for e in result.errors)
+    assert not any("Duplicate group_key" in e.message for e in result.errors)
 
 
 # ---------------------------------------------------------------------------
-# Per-mapping — matrix_row
+# Per-mapping — group requires group_key
 # ---------------------------------------------------------------------------
 
-def test_matrix_row_missing_row_key_is_error():
+def test_group_missing_group_key_is_error():
     result = validate_column_mappings(_base_mappings(**{
-        "Availability [8AM]": {"field": "availability", "type": "matrix_row"},
+        "Availability [8AM]": {"field": "availability", "field_type": "group", "value_type": "time_range"},
     }))
     assert not result.ok
-    assert any("row_key" in e.message for e in result.errors)
+    assert any("group_key" in e.message for e in result.errors)
 
-def test_matrix_row_with_row_key_ok():
+def test_group_with_group_key_ok():
     result = validate_column_mappings(_base_mappings(**{
         "Availability [8:00 AM - 10:00 AM]": {
-            "field": "availability", "type": "matrix_row",
-            "row_key": "8:00 AM - 10:00 AM",
-            "rules": [{"condition": "always", "action": "parse_availability"}],
+            "field": "availability", "field_type": "group", "value_type": "time_range",
+            "group_key": "8:00 AM - 10:00 AM",
         },
     }))
     assert result.ok
@@ -198,105 +213,115 @@ def test_matrix_row_with_row_key_ok():
 
 def test_extra_data_missing_extra_key_is_error():
     result = validate_column_mappings(_base_mappings(**{
-        "Transport": {"field": "extra_data", "type": "string"},
+        "Transport": {"field": "extra_data", "field_type": "single", "value_type": "text"},
     }))
     assert not result.ok
     assert any("extra_key" in e.message for e in result.errors)
 
-
-# ---------------------------------------------------------------------------
-# Per-mapping — delimiter on non-multi_select
-# ---------------------------------------------------------------------------
-
-def test_delimiter_on_non_multi_select_is_error():
+def test_extra_data_group_no_extra_key_ok():
+    """group extra_data uses group_key as the key — no extra_key required."""
     result = validate_column_mappings(_base_mappings(**{
-        "Notes": {"field": "notes", "type": "string", "delimiter": ";"},
+        "Which protein?": {"field": "extra_data", "field_type": "group", "value_type": "text", "group_key": "protein"},
+    }))
+    assert not any("extra_key" in e.message for e in result.errors)
+
+
+# ---------------------------------------------------------------------------
+# Per-mapping — delimiter on non-list
+# ---------------------------------------------------------------------------
+
+def test_delimiter_on_non_list_is_error():
+    result = validate_column_mappings(_base_mappings(**{
+        "Notes": {"field": "notes", "field_type": "single", "value_type": "text", "delimiter": ";"},
     }))
     assert not result.ok
     assert any("delimiter" in e.message for e in result.errors)
 
-def test_delimiter_on_multi_select_ok():
+def test_delimiter_on_list_ok():
     result = validate_column_mappings(_base_mappings(**{
-        "Role": {"field": "role_preference", "type": "multi_select", "delimiter": ";"},
+        "Role": {"field": "role_preference", "field_type": "list", "value_type": "text", "delimiter": ";"},
     }))
     assert result.ok
 
 
 # ---------------------------------------------------------------------------
-# Per-mapping — availability without parse_availability rule (warning)
+# Per-mapping — availability group_key time range format (warning)
 # ---------------------------------------------------------------------------
 
-def test_availability_matrix_row_no_rule_is_warning():
+def test_availability_group_non_time_range_value_type_is_warning():
     result = validate_column_mappings(_base_mappings(**{
         "Availability [8:00 AM - 10:00 AM]": {
-            "field": "availability", "type": "matrix_row",
-            "row_key": "8:00 AM - 10:00 AM",
+            "field": "availability", "field_type": "group",
+            "value_type": "text",   # should be "time_range"
+            "group_key": "8:00 AM - 10:00 AM",
         },
     }))
     assert result.ok  # warning only, not an error
-    assert any("parse_time_range" in w.message for w in result.warnings)
+    assert any("time_range" in w.message for w in result.warnings)
 
-def test_availability_matrix_row_with_rule_no_warning():
+def test_availability_group_time_range_no_warning():
     result = validate_column_mappings(_base_mappings(**{
         "Availability [8:00 AM - 10:00 AM]": {
-            "field": "availability", "type": "matrix_row",
-            "row_key": "8:00 AM - 10:00 AM",
-            "rules": [{"condition": "always", "action": "parse_availability"}],
+            "field": "availability", "field_type": "group", "value_type": "time_range",
+            "group_key": "8:00 AM - 10:00 AM",
         },
     }))
     assert result.ok
-    assert not any("parse_availability" in w.message for w in result.warnings)
+    assert not any("time_range" in w.message for w in result.warnings)
 
 
 # ---------------------------------------------------------------------------
-# Per-mapping — row_key time range format (warning)
+# Per-mapping — group_key time range format (warning)
 # ---------------------------------------------------------------------------
 
-def test_unparseable_row_key_is_warning():
+def test_unparseable_group_key_is_warning():
+    """Unparseable group_key warns only when field is availability."""
     result = validate_column_mappings(_base_mappings(**{
         "Availability [morning]": {
-            "field": "notes", "type": "matrix_row",
-            "row_key": "morning",
+            "field": "availability", "field_type": "group", "value_type": "time_range",
+            "group_key": "morning",
         },
     }))
     assert result.ok
-    assert not any("time range" in w.message for w in result.warnings)
+    assert any("time range" in w.message for w in result.warnings)
 
-def test_valid_row_key_no_warning():
+def test_valid_group_key_no_warning():
     result = validate_column_mappings(_base_mappings(**{
         "Availability [8:00 AM - 10:00 AM]": {
-            "field": "availability", "type": "matrix_row",
-            "row_key": "8:00 AM - 10:00 AM",
-            "rules": [{"condition": "always", "action": "parse_availability"}],
+            "field": "availability", "field_type": "group", "value_type": "time_range",
+            "group_key": "8:00 AM - 10:00 AM",
         },
     }))
     assert not any("time range" in w.message for w in result.warnings)
 
 
 # ---------------------------------------------------------------------------
-# Per-rule — parse_availability / parse_time_range
+# Per-rule — parse_time_range / parse_availability are now rejected
 # ---------------------------------------------------------------------------
 
-def test_parse_availability_on_non_matrix_row_is_ok():
+def test_parse_time_range_action_is_error():
+    """parse_time_range is no longer a valid rule action — must be rejected."""
     result = validate_column_mappings(_base_mappings(**{
-        "Notes": {
-            "field": "notes", "type": "string",
+        "Availability [8:00 AM - 10:00 AM]": {
+            "field": "availability", "field_type": "group", "value_type": "time_range",
+            "group_key": "8:00 AM - 10:00 AM",
+            "rules": [{"condition": "always", "action": "parse_time_range"}],
+        },
+    }))
+    assert not result.ok
+    assert any("parse_time_range" in e.message for e in result.errors)
+
+def test_parse_availability_action_is_error():
+    """parse_availability is no longer a valid rule action — must be rejected."""
+    result = validate_column_mappings(_base_mappings(**{
+        "Availability [8:00 AM - 10:00 AM]": {
+            "field": "availability", "field_type": "group", "value_type": "time_range",
+            "group_key": "8:00 AM - 10:00 AM",
             "rules": [{"condition": "always", "action": "parse_availability"}],
         },
     }))
-    assert result.ok
-    assert result.errors == []
-
-def test_parse_availability_non_always_condition_is_ok():
-    result = validate_column_mappings(_base_mappings(**{
-        "Availability [8:00 AM - 10:00 AM]": {
-            "field": "availability", "type": "matrix_row",
-            "row_key": "8:00 AM - 10:00 AM",
-            "rules": [{"condition": "contains", "match": "Thu", "action": "parse_availability"}],
-        },
-    }))
-    assert result.ok
-    assert not any("always" in e.message for e in result.errors)
+    assert not result.ok
+    assert any("parse_availability" in e.message for e in result.errors)
 
 
 # ---------------------------------------------------------------------------
@@ -306,7 +331,7 @@ def test_parse_availability_non_always_condition_is_ok():
 def test_invalid_regex_is_error():
     result = validate_column_mappings(_base_mappings(**{
         "Role": {
-            "field": "role_preference", "type": "string",
+            "field": "role_preference", "field_type": "single", "value_type": "text",
             "rules": [{"condition": "regex", "match": "[invalid(", "action": "set", "value": "x"}],
         },
     }))
@@ -316,7 +341,7 @@ def test_invalid_regex_is_error():
 def test_valid_regex_ok():
     result = validate_column_mappings(_base_mappings(**{
         "Role": {
-            "field": "role_preference", "type": "string",
+            "field": "role_preference", "field_type": "single", "value_type": "text",
             "rules": [{"condition": "regex", "match": r"\bGV\b", "action": "set", "value": "GV"}],
         },
     }))
@@ -330,7 +355,7 @@ def test_valid_regex_ok():
 def test_missing_match_on_contains_is_error():
     result = validate_column_mappings(_base_mappings(**{
         "Role": {
-            "field": "role_preference", "type": "string",
+            "field": "role_preference", "field_type": "single", "value_type": "text",
             "rules": [{"condition": "contains", "action": "set", "value": "GV"}],
         },
     }))
@@ -340,7 +365,7 @@ def test_missing_match_on_contains_is_error():
 def test_always_condition_no_match_ok():
     result = validate_column_mappings(_base_mappings(**{
         "Role": {
-            "field": "role_preference", "type": "string",
+            "field": "role_preference", "field_type": "single", "value_type": "text",
             "rules": [{"condition": "always", "action": "append", "value": "!"}],
         },
     }))
@@ -354,7 +379,7 @@ def test_always_condition_no_match_ok():
 def test_missing_value_on_set_is_error():
     result = validate_column_mappings(_base_mappings(**{
         "Role": {
-            "field": "role_preference", "type": "string",
+            "field": "role_preference", "field_type": "single", "value_type": "text",
             "rules": [{"condition": "always", "action": "set"}],
         },
     }))
@@ -364,7 +389,7 @@ def test_missing_value_on_set_is_error():
 def test_discard_no_value_ok():
     result = validate_column_mappings(_base_mappings(**{
         "Role": {
-            "field": "role_preference", "type": "string",
+            "field": "role_preference", "field_type": "single", "value_type": "text",
             "rules": [{"condition": "contains", "match": "n/a", "action": "discard"}],
         },
     }))
@@ -378,7 +403,7 @@ def test_discard_no_value_ok():
 def test_rule_after_set_is_warning():
     result = validate_column_mappings(_base_mappings(**{
         "Role": {
-            "field": "role_preference", "type": "string",
+            "field": "role_preference", "field_type": "single", "value_type": "text",
             "rules": [
                 {"condition": "always",   "action": "set",    "value": "GV"},
                 {"condition": "contains", "match": "GV", "action": "append", "value": "!"},
@@ -392,7 +417,7 @@ def test_rule_after_set_is_warning():
 def test_set_as_last_rule_no_warning():
     result = validate_column_mappings(_base_mappings(**{
         "Role": {
-            "field": "role_preference", "type": "string",
+            "field": "role_preference", "field_type": "single", "value_type": "text",
             "rules": [
                 {"condition": "contains", "match": "GV", "action": "append", "value": "!"},
                 {"condition": "always",   "action": "set",    "value": "GV"},
@@ -410,7 +435,7 @@ def test_set_as_last_rule_no_warning():
 def test_single_header_serialised_as_list():
     """Single-header issues must also come out as list[str] in the response."""
     result = validate_column_mappings(_base_mappings(**{
-        "Transport": {"field": "extra_data", "type": "string"},
+        "Transport": {"field": "extra_data", "field_type": "single", "value_type": "text"},
     }))
     response = result.to_response_dict()
     extra_key_error = next(e for e in response["errors"] if "extra_key" in e["message"])
@@ -420,7 +445,7 @@ def test_single_header_serialised_as_list():
 def test_none_header_serialised_as_none():
     """Config-level errors with no header must serialise as null."""
     result = validate_column_mappings({
-        "First Name": {"field": "first_name", "type": "string"},
+        "First Name": {"field": "first_name", "field_type": "single", "value_type": "text"},
     })
     response = result.to_response_dict()
     email_error = next(e for e in response["errors"] if "No column" in e["message"])
@@ -434,11 +459,11 @@ def test_none_header_serialised_as_none():
 def test_multiple_errors_all_returned():
     result = validate_column_mappings({
         # no email
-        "First Name": {"field": "first_name", "type": "string"},
-        # matrix_row missing row_key
-        "Avail": {"field": "availability", "type": "matrix_row"},
+        "First Name": {"field": "first_name", "field_type": "single", "value_type": "text"},
+        # group missing group_key
+        "Avail": {"field": "availability", "field_type": "group", "value_type": "time_range"},
         # extra_data missing extra_key
-        "Transport": {"field": "extra_data", "type": "string"},
+        "Transport": {"field": "extra_data", "field_type": "single", "value_type": "text"},
     })
     assert not result.ok
     assert len(result.errors) >= 3

--- a/backend/tests/services/test_sync_service.py
+++ b/backend/tests/services/test_sync_service.py
@@ -11,7 +11,7 @@ from app.services.sync_service import (
     _apply_rules,
     _process_cell,
 )
-from app.schemas.sheet_config import coerce_legacy_type
+from app.schemas.sheet_config import coerce_legacy_mapping
 from unittest.mock import MagicMock
 
 
@@ -184,49 +184,61 @@ def test_merge_availability_with_existing():
 
 
 # ---------------------------------------------------------------------------
-# coerce_legacy_type
+# coerce_legacy_mapping
 # ---------------------------------------------------------------------------
 
-def test_coerce_legacy_availability_row():
-    assert coerce_legacy_type("availability_row") == "matrix_row"
+def test_coerce_legacy_mapping_string():
+    result = coerce_legacy_mapping({"field": "email", "type": "string"})
+    assert result["field_type"] == "single"
+    assert result["value_type"] == "text"
+    assert "type" not in result
 
-def test_coerce_legacy_category_events():
-    assert coerce_legacy_type("category_events") == "string"
+def test_coerce_legacy_mapping_boolean():
+    result = coerce_legacy_mapping({"field": "extra_data", "type": "boolean"})
+    assert result["field_type"] == "single"
+    assert result["value_type"] == "boolean"
 
-def test_coerce_current_type_unchanged():
-    for t in ("string", "ignore", "boolean", "integer", "multi_select", "matrix_row"):
-        assert coerce_legacy_type(t) == t
+def test_coerce_legacy_mapping_integer():
+    result = coerce_legacy_mapping({"field": "extra_data", "type": "integer"})
+    assert result["field_type"] == "single"
+    assert result["value_type"] == "number"
 
+def test_coerce_legacy_mapping_multi_select():
+    result = coerce_legacy_mapping({"field": "role_preference", "type": "multi_select"})
+    assert result["field_type"] == "list"
+    assert result["value_type"] == "text"
 
-# ---------------------------------------------------------------------------
-# _process_cell — legacy type coercion
-# ---------------------------------------------------------------------------
+def test_coerce_legacy_mapping_matrix_row():
+    result = coerce_legacy_mapping({"field": "availability", "type": "matrix_row", "row_key": "8:00 AM - 10:00 AM"})
+    assert result["field_type"] == "group"
+    assert result["value_type"] == "text"
+    assert result["group_key"] == "8:00 AM - 10:00 AM"
+    assert "row_key" not in result
 
-def test_process_cell_legacy_availability_row_coerced(caplog):
-    """availability_row is coerced to matrix_row. Without a parse_availability
-    rule, matrix_row returns the raw string — the TD must add the rule."""
+def test_coerce_legacy_mapping_ignore():
+    result = coerce_legacy_mapping({"field": "__ignore__", "type": "ignore"})
+    assert result["field_type"] == "ignore"
+    assert "value_type" not in result
+
+def test_coerce_legacy_mapping_availability_row_alias(caplog):
     import logging
-    t = _make_tournament(NATS_BLOCKS)
-    mapping = {
-        "field": "availability",
-        "type": "availability_row",
-        "row_key": "8:00 AM - 10:00 AM",
-    }
     with caplog.at_level(logging.WARNING):
-        result = _process_cell("Thursday 5/21", mapping, t)
-    assert result == "Thursday 5/21"
+        result = coerce_legacy_mapping({"field": "availability", "type": "availability_row", "row_key": "8:00 AM - 10:00 AM"})
+    assert result["field_type"] == "group"
+    assert result["value_type"] == "text"
     assert "availability_row" in caplog.text
 
+def test_coerce_legacy_mapping_already_new_schema():
+    """Mappings already using field_type/value_type are left untouched."""
+    result = coerce_legacy_mapping({"field": "email", "field_type": "single", "value_type": "text"})
+    assert result["field_type"] == "single"
+    assert result["value_type"] == "text"
+    assert "type" not in result
 
-def test_process_cell_legacy_category_events_coerced(caplog):
-    """category_events is coerced to string and returns raw value."""
-    import logging
-    t = _make_tournament(NATS_BLOCKS)
-    mapping = {"field": "event_preference", "type": "category_events"}
-    with caplog.at_level(logging.WARNING):
-        result = _process_cell("Technology & Engineering (Boomilever)", mapping, t)
-    assert result == "Technology & Engineering (Boomilever)"
-    assert "category_events" in caplog.text
+def test_coerce_legacy_mapping_row_key_renamed():
+    result = coerce_legacy_mapping({"field": "availability", "field_type": "group", "value_type": "time_range", "row_key": "8:00 AM - 10:00 AM"})
+    assert result["group_key"] == "8:00 AM - 10:00 AM"
+    assert "row_key" not in result
 
 
 # ---------------------------------------------------------------------------
@@ -321,30 +333,104 @@ def test_apply_rules_sequential_all_fire():
     result = _apply_rules("General Volunteer, Event Supervisor", rules, {}, _t())
     assert result == "GV, ES"
 
-def test_apply_rules_parse_availability_short_circuits():
-    """parse_availability returns a list and stops rule processing."""
-    mapping = {"row_key": "8:00 AM - 10:00 AM"}
-    rules = [
-        {"condition": "always", "action": "parse_availability"},
-        # this rule would fire on a string but should never run
-        {"condition": "always", "action": "set", "value": "SHOULD NOT APPEAR"},
-    ]
-    result = _apply_rules("Thursday 5/21", rules, mapping, _make_tournament(NATS_BLOCKS))
-    assert isinstance(result, list)
-    assert result == [{"date": "2026-05-21", "start": "08:00", "end": "10:00"}]
-
-def test_apply_rules_parse_availability_without_row_key_extracts_from_value():
-    rules = [{"condition": "always", "action": "parse_time_range"}]
-    result = _apply_rules(
-        "February 14 7:00AM - 5:00PM",
-        rules,
-        {},
-        _make_tournament(start_date=datetime(2026, 5, 21)),
-    )
-    assert result == [{"date": "2026-02-14", "start": "07:00", "end": "17:00"}]
-
 def test_apply_rules_empty_rules_unchanged():
     assert _apply_rules("hello", [], {}, _t()) == "hello"
+
+
+# ---------------------------------------------------------------------------
+# _process_cell — value_type dispatch
+# ---------------------------------------------------------------------------
+
+def test_process_cell_single_text():
+    t = _make_tournament(NATS_BLOCKS)
+    mapping = {"field": "notes", "field_type": "single", "value_type": "text"}
+    assert _process_cell("Hello", mapping, t) == "Hello"
+
+def test_process_cell_single_boolean_yes():
+    t = _make_tournament(NATS_BLOCKS)
+    mapping = {"field": "extra_data", "field_type": "single", "value_type": "boolean", "extra_key": "competed"}
+    assert _process_cell("Yes", mapping, t) is True
+
+def test_process_cell_single_boolean_no():
+    t = _make_tournament(NATS_BLOCKS)
+    mapping = {"field": "extra_data", "field_type": "single", "value_type": "boolean", "extra_key": "competed"}
+    assert _process_cell("No", mapping, t) is False
+
+def test_process_cell_single_number_int():
+    t = _make_tournament(NATS_BLOCKS)
+    mapping = {"field": "extra_data", "field_type": "single", "value_type": "number", "extra_key": "seats"}
+    assert _process_cell("3", mapping, t) == 3
+
+def test_process_cell_single_number_float():
+    t = _make_tournament(NATS_BLOCKS)
+    mapping = {"field": "extra_data", "field_type": "single", "value_type": "number", "extra_key": "gpa"}
+    assert _process_cell("3.8", mapping, t) == 3.8
+
+def test_process_cell_single_number_invalid():
+    t = _make_tournament(NATS_BLOCKS)
+    mapping = {"field": "extra_data", "field_type": "single", "value_type": "number", "extra_key": "seats"}
+    assert _process_cell("abc", mapping, t) is None
+
+def test_process_cell_ignore():
+    t = _make_tournament(NATS_BLOCKS)
+    mapping = {"field": "__ignore__", "field_type": "ignore"}
+    assert _process_cell("anything", mapping, t) is None
+
+def test_process_cell_list_text():
+    t = _make_tournament(NATS_BLOCKS)
+    mapping = {"field": "role_preference", "field_type": "list", "value_type": "text"}
+    result = _process_cell("Event Supervisor,General Volunteer,Floater", mapping, t)
+    assert result == ["Event Supervisor", "General Volunteer", "Floater"]
+
+def test_process_cell_list_custom_delimiter():
+    t = _make_tournament(NATS_BLOCKS)
+    mapping = {"field": "role_preference", "field_type": "list", "value_type": "text", "delimiter": ";"}
+    result = _process_cell("Event Supervisor;General Volunteer;Floater", mapping, t)
+    assert result == ["Event Supervisor", "General Volunteer", "Floater"]
+
+def test_process_cell_list_number():
+    t = _make_tournament(NATS_BLOCKS)
+    mapping = {"field": "extra_data", "field_type": "list", "value_type": "number", "extra_key": "scores"}
+    result = _process_cell("1,2,3", mapping, t)
+    assert result == [1, 2, 3]
+
+def test_process_cell_group_text():
+    """group field_type with text value returns the coerced scalar."""
+    t = _make_tournament(NATS_BLOCKS)
+    mapping = {"field": "lunch_order", "field_type": "group", "value_type": "text", "group_key": "protein"}
+    result = _process_cell("Carnitas", mapping, t)
+    assert result == "Carnitas"
+
+def test_process_cell_group_text_blank():
+    """Blank group cell returns None; sync_sheet stores '' for that key."""
+    t = _make_tournament(NATS_BLOCKS)
+    mapping = {"field": "lunch_order", "field_type": "group", "value_type": "text", "group_key": "drink"}
+    result = _process_cell("", mapping, t)
+    assert result is None
+
+def test_process_cell_group_time_range_returns_slots():
+    """group + time_range produces availability slots list."""
+    t = _make_tournament(NATS_BLOCKS)
+    mapping = {
+        "field": "availability",
+        "field_type": "group",
+        "value_type": "time_range",
+        "group_key": "8:00 AM - 10:00 AM",
+    }
+    result = _process_cell("Thursday 5/21", mapping, t)
+    assert result == [{"date": "2026-05-21", "start": "08:00", "end": "10:00"}]
+
+def test_process_cell_group_time_range_without_group_key_extracts_from_value():
+    """time_range with no group_key extracts the time range from the value itself."""
+    t = _make_tournament(start_date=datetime(2026, 5, 21))
+    mapping = {
+        "field": "availability",
+        "field_type": "group",
+        "value_type": "time_range",
+        "group_key": "",
+    }
+    result = _process_cell("February 14 7:00AM - 5:00PM", mapping, t)
+    assert result == [{"date": "2026-02-14", "start": "07:00", "end": "17:00"}]
 
 
 # ---------------------------------------------------------------------------
@@ -356,7 +442,8 @@ def test_process_cell_rules_run_before_type_coercion():
     t = _make_tournament(NATS_BLOCKS)
     mapping = {
         "field": "extra_data",
-        "type": "boolean",
+        "field_type": "single",
+        "value_type": "boolean",
         "extra_key": "competed",
         "rules": [{"condition": "contains", "match": "yes i have", "action": "set", "value": "yes"}],
     }
@@ -366,80 +453,76 @@ def test_process_cell_rules_discard_returns_none():
     t = _make_tournament(NATS_BLOCKS)
     mapping = {
         "field": "notes",
-        "type": "string",
+        "field_type": "single",
+        "value_type": "text",
         "rules": [{"condition": "equals", "match": "n/a", "action": "discard"}],
     }
     assert _process_cell("N/A", mapping, t) is None
 
-def test_process_cell_multi_select_custom_delimiter():
-    t = _make_tournament(NATS_BLOCKS)
-    mapping = {"field": "role_preference", "type": "multi_select", "delimiter": ";"}
-    result = _process_cell("Event Supervisor;General Volunteer;Floater", mapping, t)
-    assert result == ["Event Supervisor", "General Volunteer", "Floater"]
-
-def test_process_cell_parse_availability_via_rule():
-    """matrix_row + parse_availability rule produces slots list."""
-    t = _make_tournament(NATS_BLOCKS)
-    mapping = {
-        "field": "availability",
-        "type": "matrix_row",
-        "row_key": "8:00 AM - 10:00 AM",
-        "rules": [{"condition": "always", "action": "parse_availability"}],
-    }
-    result = _process_cell("Thursday 5/21", mapping, t)
-    assert result == [{"date": "2026-05-21", "start": "08:00", "end": "10:00"}]
-
-def test_process_cell_matrix_row_no_rule_returns_string():
-    """matrix_row without a parse_availability rule stores raw string."""
-    t = _make_tournament(NATS_BLOCKS)
-    mapping = {"field": "availability", "type": "matrix_row", "row_key": "8:00 AM - 10:00 AM"}
-    result = _process_cell("Thursday 5/21", mapping, t)
-    assert result == "Thursday 5/21"
-
-def test_process_cell_string_parse_time_range_rule():
-    t = _make_tournament(start_date=datetime(2026, 5, 21))
-    mapping = {
-        "field": "availability",
-        "type": "string",
-        "rules": [{"condition": "always", "action": "parse_time_range"}],
-    }
-    result = _process_cell("February 14 7:00AM - 5:00PM", mapping, t)
-    assert result == [{"date": "2026-02-14", "start": "07:00", "end": "17:00"}]
-
 
 def test_process_cell_phone_formats_us_number():
     t = _make_tournament(NATS_BLOCKS)
-    mapping = {"field": "phone", "type": "string"}
+    mapping = {"field": "phone", "field_type": "single", "value_type": "text"}
     assert _process_cell("9495551234", mapping, t) == "(949) 555-1234"
     assert _process_cell("+1 (949) 555-1234", mapping, t) == "(949) 555-1234"
 
 
 # ---------------------------------------------------------------------------
-# Generic matrix_row aggregation in sync_sheet
+# _process_cell — legacy type coercion (backward compat via coerce_legacy_mapping)
 # ---------------------------------------------------------------------------
-# These tests exercise the dispatch logic directly via _process_cell and verify
-# that matrix_row fields (other than availability/event_preference) produce the
-# right processed value, which sync_sheet then accumulates into a dict.
 
-def test_process_cell_matrix_row_returns_string_value():
-    """matrix_row without a parse rule returns the raw string — sync_sheet builds the dict."""
+def test_process_cell_legacy_matrix_row_coerced(caplog):
+    """Legacy matrix_row type is coerced to group/text via coerce_legacy_mapping."""
+    import logging
     t = _make_tournament(NATS_BLOCKS)
-    mapping = {"field": "lunch_order", "type": "matrix_row", "row_key": "protein"}
+    mapping = {
+        "field": "lunch_order",
+        "type": "matrix_row",
+        "row_key": "protein",
+    }
+    result = _process_cell("Carnitas", mapping, t)
+    assert result == "Carnitas"
+
+def test_process_cell_legacy_availability_row_coerced(caplog):
+    """availability_row alias is coerced through to group/text, no rules → raw string."""
+    import logging
+    t = _make_tournament(NATS_BLOCKS)
+    mapping = {
+        "field": "availability",
+        "type": "availability_row",
+        "row_key": "8:00 AM - 10:00 AM",
+    }
+    with caplog.at_level(logging.WARNING):
+        result = _process_cell("Thursday 5/21", mapping, t)
+    assert result == "Thursday 5/21"
+    assert "availability_row" in caplog.text
+
+def test_process_cell_legacy_category_events_coerced(caplog):
+    """category_events is coerced to single/text and returns raw value."""
+    import logging
+    t = _make_tournament(NATS_BLOCKS)
+    mapping = {"field": "event_preference", "type": "category_events"}
+    with caplog.at_level(logging.WARNING):
+        result = _process_cell("Technology & Engineering (Boomilever)", mapping, t)
+    assert result == "Technology & Engineering (Boomilever)"
+    assert "category_events" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Generic group aggregation in sync_sheet
+# ---------------------------------------------------------------------------
+
+def test_process_cell_group_returns_string_value():
+    """group without time_range returns the raw string — sync_sheet builds the dict."""
+    t = _make_tournament(NATS_BLOCKS)
+    mapping = {"field": "lunch_order", "field_type": "group", "value_type": "text", "group_key": "protein"}
     result = _process_cell("Carnitas", mapping, t)
     assert result == "Carnitas"
 
 
-def test_process_cell_matrix_row_blank_returns_none():
-    """Blank matrix_row cell returns None; sync_sheet stores '' for that key."""
-    t = _make_tournament(NATS_BLOCKS)
-    mapping = {"field": "lunch_order", "type": "matrix_row", "row_key": "drink"}
-    result = _process_cell("", mapping, t)
-    assert result is None
-
-
 def test_process_cell_lunch_order_string_returns_value():
-    """lunch_order with type=string (single-header legacy config) returns the raw string."""
+    """lunch_order with field_type=single (single-header config) returns the raw string."""
     t = _make_tournament(NATS_BLOCKS)
-    mapping = {"field": "lunch_order", "type": "string"}
+    mapping = {"field": "lunch_order", "field_type": "single", "value_type": "text"}
     result = _process_cell("Carnitas bowl", mapping, t)
     assert result == "Carnitas bowl"

--- a/frontend/app/dashboard/[tournamentId]/sheets/[configId]/edit/page.tsx
+++ b/frontend/app/dashboard/[tournamentId]/sheets/[configId]/edit/page.tsx
@@ -49,12 +49,13 @@ function emptyMappingRow(header: string, s?: Partial<ColumnMappingEntry>): Mappi
   return {
     column_index: s?.column_index ?? -1,
     header,
-    field:     s?.field     ?? "__ignore__",
-    type:      s?.type      ?? "ignore",
-    row_key:   s?.row_key   ?? "",
-    extra_key: s?.extra_key ?? "",
-    delimiter: s?.delimiter ?? "",
-    rules:     s?.rules     ?? [],
+    field:      s?.field      ?? "__ignore__",
+    field_type: s?.field_type ?? "ignore",
+    value_type: s?.value_type ?? "",
+    group_key:  s?.group_key  ?? "",
+    extra_key:  s?.extra_key  ?? "",
+    delimiter:  s?.delimiter  ?? "",
+    rules:      s?.rules      ?? [],
   };
 }
 
@@ -88,9 +89,10 @@ export default function EditSheetPage() {
 
   // Headers + mapping
   const [mappingRows,     setMappingRows]     = useState<RichMappingRow[]>([]);
-  const [knownFields,     setKnownFields]     = useState<string[]>([]);
-  const [validTypes,      setValidTypes]      = useState<string[]>([]);
-  const [validConditions, setValidConditions] = useState<string[]>([]);
+  const [knownFields,      setKnownFields]      = useState<string[]>([]);
+  const [validFieldTypes,  setValidFieldTypes]  = useState<string[]>([]);
+  const [validValueTypes,  setValidValueTypes]  = useState<string[]>([]);
+  const [validConditions,  setValidConditions]  = useState<string[]>([]);
   const [validActions,    setValidActions]    = useState<string[]>([]);
   const [headersLoading,  setHeadersLoading]  = useState(false);
   const [headersError,    setHeadersError]    = useState("");
@@ -171,7 +173,8 @@ export default function EditSheetPage() {
       if (controller.signal.aborted) return;
 
       setKnownFields(result.known_fields);
-      setValidTypes(result.valid_types);
+      setValidFieldTypes(result.valid_field_types);
+      setValidValueTypes(result.valid_value_types);
       setValidConditions(result.valid_rule_conditions);
       setValidActions(result.valid_rule_actions);
 
@@ -201,12 +204,13 @@ export default function EditSheetPage() {
           rows.push(makeRichRow(base, base, undefined, undefined, (saved.rules?.length ?? 0) > 0, options));
         } else {
           const base = emptyMappingRow(m.header, {
-            field:     m.field,
-            type:      m.type as ColumnMapping["type"],
-            row_key:   m.row_key,
-            extra_key: m.extra_key,
-            rules:     m.rules,
-            delimiter: m.delimiter,
+            field:      m.field,
+            field_type: m.field_type,
+            value_type: m.value_type,
+            group_key:  m.group_key,
+            extra_key:  m.extra_key,
+            rules:      m.rules,
+            delimiter:  m.delimiter,
           });
           base.column_index = m.column_index;
           rows.push(makeRichRow(base, base, "new", undefined, undefined, options));
@@ -289,9 +293,10 @@ export default function EditSheetPage() {
       const activeRows: MappingRow[] = mappingRows
         .filter((r) => r.state !== "removed")
         .map((r) => ({
-        column_index: r.column_index,
-        header: r.header, field: r.field, type: r.type,
-          row_key: r.row_key, extra_key: r.extra_key,
+          column_index: r.column_index,
+          header: r.header, field: r.field,
+          field_type: r.field_type, value_type: r.value_type,
+          group_key: r.group_key, extra_key: r.extra_key,
           delimiter: r.delimiter, rules: r.rules,
         }));
 
@@ -350,10 +355,14 @@ export default function EditSheetPage() {
     const result: ColumnMappingEntry[] = [];
     for (const row of mappingRows) {
       if (row.state === "removed") continue;
-      const mapping: ColumnMapping = { field: row.field, type: row.type as ColumnMapping["type"] };
-      if (row.type === "matrix_row"   && row.row_key)    mapping.row_key   = row.row_key;
-      if (row.field === "extra_data"  && row.extra_key)  mapping.extra_key = row.extra_key;
-      if (row.type === "multi_select" && row.delimiter)  mapping.delimiter = row.delimiter;
+      const mapping: ColumnMapping = {
+        field:      row.field,
+        field_type: row.field_type as ColumnMapping["field_type"],
+        value_type: (row.value_type || null) as ColumnMapping["value_type"],
+      };
+      if (row.field_type === "group"   && row.group_key)  mapping.group_key = row.group_key;
+      if (row.field === "extra_data"   && row.extra_key)  mapping.extra_key = row.extra_key;
+      if (row.field_type === "list"    && row.delimiter)  mapping.delimiter = row.delimiter;
       if (row.rules.length > 0) mapping.rules = row.rules;
       // Persist form enrichment so alias editor works on next edit + in exports
       const enrichment = headerOptions.get(row.column_index);
@@ -539,7 +548,8 @@ export default function EditSheetPage() {
             <SheetConfigMappingTable
               rows={mappingRows}
               knownFields={knownFields}
-              validTypes={validTypes}
+              validFieldTypes={validFieldTypes}
+              validValueTypes={validValueTypes}
               validConditions={validConditions}
               validActions={validActions}
               onChangeRow={updateRow}

--- a/frontend/app/dashboard/[tournamentId]/sheets/[configId]/page.tsx
+++ b/frontend/app/dashboard/[tournamentId]/sheets/[configId]/page.tsx
@@ -194,13 +194,14 @@ export default function ViewSheetConfigPage() {
         const rows: RichMappingRow[] = cfg.column_mappings.map((mapping) => {
           const base = {
             column_index: mapping.column_index,
-            header: mapping.header,
-            field:     mapping.field     ?? "__ignore__",
-            type:      mapping.type      ?? "ignore",
-            row_key:   mapping.row_key   ?? "",
-            extra_key: mapping.extra_key ?? "",
-            delimiter: mapping.delimiter ?? "",
-            rules:     mapping.rules     ?? [],
+            header:     mapping.header,
+            field:      mapping.field      ?? "__ignore__",
+            field_type: mapping.field_type ?? "ignore",
+            value_type: mapping.value_type ?? "",
+            group_key:  mapping.group_key  ?? "",
+            extra_key:  mapping.extra_key  ?? "",
+            delimiter:  mapping.delimiter  ?? "",
+            rules:      mapping.rules      ?? [],
           };
           return makeRichRow(base, base);
         });
@@ -267,8 +268,8 @@ export default function ViewSheetConfigPage() {
   }
 
   const mappingEntries = config.column_mappings;
-  const mappedCount    = mappingEntries.filter((m) => m.type !== "ignore").length;
-  const ignoredCount   = mappingEntries.filter((m) => m.type === "ignore").length;
+  const mappedCount    = mappingEntries.filter((m) => m.field_type !== "ignore").length;
+  const ignoredCount   = mappingEntries.filter((m) => m.field_type === "ignore").length;
 
   return (
     <div style={{ width: "100%" }}>
@@ -342,7 +343,8 @@ export default function ViewSheetConfigPage() {
           <SheetConfigMappingTable
             rows={viewRows}
             knownFields={[]}
-            validTypes={[]}
+            validFieldTypes={[]}
+            validValueTypes={[]}
             viewOnly
           />
         </div>

--- a/frontend/app/dashboard/[tournamentId]/sheets/new/page.tsx
+++ b/frontend/app/dashboard/[tournamentId]/sheets/new/page.tsx
@@ -76,12 +76,13 @@ function emptyMappingRow(header: string, m: MappedHeader): MappingRow {
   return {
     column_index: m.column_index,
     header,
-    field:     m.field     ?? "__ignore__",
-    type:      m.type      ?? "ignore",
-    row_key:   m.row_key   ?? "",
-    extra_key: m.extra_key ?? "",
-    delimiter: m.delimiter ?? "",
-    rules:     m.rules     ?? [],
+    field:      m.field      ?? "__ignore__",
+    field_type: m.field_type ?? "ignore",
+    value_type: m.value_type ?? "",
+    group_key:  m.group_key  ?? "",
+    extra_key:  m.extra_key  ?? "",
+    delimiter:  m.delimiter  ?? "",
+    rules:      m.rules      ?? [],
   };
 }
 
@@ -317,8 +318,9 @@ export default function NewSheetPage() {
 
       const plainRows: MappingRow[] = mappingRows.map((r) => ({
         column_index: r.column_index,
-        header: r.header, field: r.field, type: r.type,
-        row_key: r.row_key, extra_key: r.extra_key,
+        header: r.header, field: r.field,
+        field_type: r.field_type, value_type: r.value_type,
+        group_key: r.group_key, extra_key: r.extra_key,
         delimiter: r.delimiter, rules: r.rules,
       }));
 
@@ -373,10 +375,14 @@ export default function NewSheetPage() {
   const buildColumnMappings = useCallback((): ColumnMappingEntry[] => {
     const result: ColumnMappingEntry[] = [];
     for (const row of mappingRows) {
-      const mapping: ColumnMapping = { field: row.field, type: row.type as ColumnMapping["type"] };
-      if (row.type === "matrix_row"   && row.row_key)   mapping.row_key   = row.row_key;
-      if (row.field === "extra_data"  && row.extra_key) mapping.extra_key = row.extra_key;
-      if (row.type === "multi_select" && row.delimiter) mapping.delimiter = row.delimiter;
+      const mapping: ColumnMapping = {
+        field:      row.field,
+        field_type: row.field_type as ColumnMapping["field_type"],
+        value_type: (row.value_type || null) as ColumnMapping["value_type"],
+      };
+      if (row.field_type === "group"    && row.group_key)  mapping.group_key = row.group_key;
+      if (row.field === "extra_data"    && row.extra_key)  mapping.extra_key = row.extra_key;
+      if (row.field_type === "list"     && row.delimiter)  mapping.delimiter = row.delimiter;
       if (row.rules.length > 0) mapping.rules = row.rules;
       // Persist form enrichment so edit page + exports retain alias editor context
       const enrichment = headerOptions.get(row.column_index);
@@ -595,7 +601,8 @@ export default function NewSheetPage() {
           <SheetConfigMappingTable
             rows={mappingRows}
             knownFields={headersResult.known_fields}
-            validTypes={headersResult.valid_types}
+            validFieldTypes={headersResult.valid_field_types}
+            validValueTypes={headersResult.valid_value_types}
             validConditions={headersResult.valid_rule_conditions}
             validActions={headersResult.valid_rule_actions}
             onChangeRow={updateRow}

--- a/frontend/app/dashboard/[tournamentId]/sheets/page.tsx
+++ b/frontend/app/dashboard/[tournamentId]/sheets/page.tsx
@@ -361,7 +361,7 @@ function ConfigCard({
     }
   }
 
-  const mappingCount = cfg.column_mappings.filter((m) => m.type !== "ignore").length;
+  const mappingCount = cfg.column_mappings.filter((m) => m.field_type !== "ignore").length;
 
   return (
     <>

--- a/frontend/components/ui/SheetConfigMappingTable.tsx
+++ b/frontend/components/ui/SheetConfigMappingTable.tsx
@@ -1027,7 +1027,7 @@ const MappingRowComponent = memo(function MappingRowComponent({
         {/* Col 2: field */}
         {viewOnly ? (
           <span style={{ fontFamily: "var(--font-sans)", fontSize: "12px", color: isIgnored ? "var(--color-text-tertiary)" : "var(--color-text-primary)" }}>
-            {isIgnored ? "—" : (KNOWN_FIELDS_LABELS[row.field] ?? row.field)}
+            {isIgnored ? "Ignore" : (KNOWN_FIELDS_LABELS[row.field] ?? row.field)}
           </span>
         ) : (
           <Select
@@ -1044,7 +1044,7 @@ const MappingRowComponent = memo(function MappingRowComponent({
         {/* Col 3: field type */}
         {viewOnly ? (
           <span style={{ fontFamily: "var(--font-sans)", fontSize: "12px", color: "var(--color-text-secondary)" }}>
-            {FIELD_TYPE_LABELS[row.field_type] ?? row.field_type}
+            {isIgnored ? "—" : (FIELD_TYPE_LABELS[row.field_type] ?? row.field_type)}
           </span>
         ) : (
           <Select

--- a/frontend/components/ui/SheetConfigMappingTable.tsx
+++ b/frontend/components/ui/SheetConfigMappingTable.tsx
@@ -938,12 +938,7 @@ const MappingRowComponent = memo(function MappingRowComponent({
   function handleFieldTypeChange(field_type: string) {
     if (!onChange) return;
     const patch: Partial<RichMappingRow> = { field_type };
-    if (field_type === "ignore") {
-      patch.field      = "__ignore__";
-      patch.value_type = "";
-    } else if (!row.value_type) {
-      patch.value_type = "text";
-    }
+    if (!row.value_type) patch.value_type = "text";
     onChange(patch);
   }
 
@@ -1046,16 +1041,16 @@ const MappingRowComponent = memo(function MappingRowComponent({
           />
         )}
 
-        {/* Col 3: field type */}
-        {viewOnly ? (
-          <span style={{ fontFamily: "var(--font-sans)", fontSize: "12px", color: "var(--color-text-secondary)" }}>
-            {FIELD_TYPE_LABELS[row.field_type] ?? row.field_type}
+        {/* Col 3: field type — locked (shows —) when field is ignored */}
+        {viewOnly || isIgnored ? (
+          <span style={{ fontFamily: "var(--font-sans)", fontSize: "12px", color: "var(--color-text-tertiary)", opacity: isIgnored ? 0.4 : 1 }}>
+            {isIgnored ? "—" : (FIELD_TYPE_LABELS[row.field_type] ?? row.field_type)}
           </span>
         ) : (
           <Select
             value={row.field_type}
             onChange={handleFieldTypeChange}
-            options={validFieldTypes.map((t) => ({ value: t, label: FIELD_TYPE_LABELS[t] ?? t }))}
+            options={validFieldTypes.filter((t) => t !== "ignore").map((t) => ({ value: t, label: FIELD_TYPE_LABELS[t] ?? t }))}
             disabled={isRemoved}
             size="sm"
             background="var(--color-bg)"
@@ -1063,17 +1058,17 @@ const MappingRowComponent = memo(function MappingRowComponent({
           />
         )}
 
-        {/* Col 4: value type */}
-        {viewOnly ? (
-          <span style={{ fontFamily: "var(--font-sans)", fontSize: "12px", color: "var(--color-text-secondary)" }}>
-            {row.value_type ? (VALUE_TYPE_LABELS[row.value_type] ?? row.value_type) : "—"}
+        {/* Col 4: value type — locked (shows —) when field is ignored */}
+        {viewOnly || isIgnored ? (
+          <span style={{ fontFamily: "var(--font-sans)", fontSize: "12px", color: "var(--color-text-tertiary)", opacity: isIgnored ? 0.4 : 1 }}>
+            {isIgnored ? "—" : (row.value_type ? (VALUE_TYPE_LABELS[row.value_type] ?? row.value_type) : "—")}
           </span>
         ) : (
           <Select
             value={row.value_type ?? ""}
             onChange={handleValueTypeChange}
             options={validValueTypes.map((t) => ({ value: t, label: VALUE_TYPE_LABELS[t] ?? t }))}
-            disabled={isRemoved || isIgnored}
+            disabled={isRemoved}
             size="sm"
             background="var(--color-bg)"
             fullWidth

--- a/frontend/components/ui/SheetConfigMappingTable.tsx
+++ b/frontend/components/ui/SheetConfigMappingTable.tsx
@@ -1041,34 +1041,37 @@ const MappingRowComponent = memo(function MappingRowComponent({
           />
         )}
 
-        {/* Col 3: field type — locked (shows —) when field is ignored */}
-        {viewOnly || isIgnored ? (
-          <span style={{ fontFamily: "var(--font-sans)", fontSize: "12px", color: "var(--color-text-tertiary)", opacity: isIgnored ? 0.4 : 1 }}>
-            {isIgnored ? "—" : (FIELD_TYPE_LABELS[row.field_type] ?? row.field_type)}
+        {/* Col 3: field type */}
+        {viewOnly ? (
+          <span style={{ fontFamily: "var(--font-sans)", fontSize: "12px", color: "var(--color-text-secondary)" }}>
+            {FIELD_TYPE_LABELS[row.field_type] ?? row.field_type}
           </span>
         ) : (
           <Select
             value={row.field_type}
             onChange={handleFieldTypeChange}
-            options={validFieldTypes.filter((t) => t !== "ignore").map((t) => ({ value: t, label: FIELD_TYPE_LABELS[t] ?? t }))}
-            disabled={isRemoved}
+            options={[
+              ...validFieldTypes.filter((t) => t !== "ignore").map((t) => ({ value: t, label: FIELD_TYPE_LABELS[t] ?? t })),
+              ...(isIgnored ? [{ value: "ignore", label: "Ignore" }] : []),
+            ]}
+            disabled={isRemoved || isIgnored}
             size="sm"
             background="var(--color-bg)"
             fullWidth
           />
         )}
 
-        {/* Col 4: value type — locked (shows —) when field is ignored */}
-        {viewOnly || isIgnored ? (
-          <span style={{ fontFamily: "var(--font-sans)", fontSize: "12px", color: "var(--color-text-tertiary)", opacity: isIgnored ? 0.4 : 1 }}>
-            {isIgnored ? "—" : (row.value_type ? (VALUE_TYPE_LABELS[row.value_type] ?? row.value_type) : "—")}
+        {/* Col 4: value type — disabled when ignored */}
+        {viewOnly ? (
+          <span style={{ fontFamily: "var(--font-sans)", fontSize: "12px", color: "var(--color-text-secondary)" }}>
+            {row.value_type ? (VALUE_TYPE_LABELS[row.value_type] ?? row.value_type) : "—"}
           </span>
         ) : (
           <Select
             value={row.value_type ?? ""}
             onChange={handleValueTypeChange}
             options={validValueTypes.map((t) => ({ value: t, label: VALUE_TYPE_LABELS[t] ?? t }))}
-            disabled={isRemoved}
+            disabled={isRemoved || isIgnored}
             size="sm"
             background="var(--color-bg)"
             fullWidth

--- a/frontend/components/ui/SheetConfigMappingTable.tsx
+++ b/frontend/components/ui/SheetConfigMappingTable.tsx
@@ -32,13 +32,19 @@ export const KNOWN_FIELDS_LABELS: Record<string, string> = {
   "extra_data":          "Extra Data",
 };
 
-export const TYPE_LABELS: Record<string, string> = {
-  string:       "Text",
-  ignore:       "Ignore",
-  boolean:      "Yes/No",
-  integer:      "Number",
-  multi_select: "Multi-select",
-  matrix_row:   "Matrix Row",
+export const FIELD_TYPE_LABELS: Record<string, string> = {
+  single: "Single",
+  list:   "List",
+  group:  "Group",
+  ignore: "Ignore",
+};
+
+export const VALUE_TYPE_LABELS: Record<string, string> = {
+  text:       "Text",
+  number:     "Number",
+  boolean:    "Yes / No",
+  date:       "Date",
+  time_range: "Time Range",
 };
 
 const CONDITION_LABELS: Record<string, string> = {
@@ -51,21 +57,14 @@ const CONDITION_LABELS: Record<string, string> = {
 };
 
 const ACTION_LABELS: Record<string, string> = {
-  set:               "Set to",
-  replace:           "Replace with",
-  prepend:           "Prepend",
-  append:            "Append",
-  discard:           "Discard",
-  parse_time_range:  "Parse time range",   // canonical
-  parse_availability:"Parse availability", // legacy alias
+  set:     "Set to",
+  replace: "Replace with",
+  prepend: "Prepend",
+  append:  "Append",
+  discard: "Discard",
 };
 
-// Both parse_time_range and parse_availability take no value argument.
-const VALUELESS_ACTIONS = new Set<ParseRuleAction>([
-  "discard",
-  "parse_time_range",
-  "parse_availability",
-]);
+const VALUELESS_ACTIONS = new Set<ParseRuleAction>(["discard"]);
 
 // ─── Row state ────────────────────────────────────────────────────────────────
 
@@ -393,10 +392,11 @@ interface DiffLine {
 }
 
 const FIELD_DEFS: { label: string; key: keyof MappingRow; fmt?: (v: string) => string }[] = [
-  { label: "Field",     key: "field",     fmt: (v) => KNOWN_FIELDS_LABELS[v] ?? v },
-  { label: "Type",      key: "type",      fmt: (v) => TYPE_LABELS[v] ?? v },
-  { label: "Row Key",   key: "row_key" },
-  { label: "Extra Key", key: "extra_key" },
+  { label: "Field",      key: "field",      fmt: (v) => KNOWN_FIELDS_LABELS[v] ?? v },
+  { label: "Field Type", key: "field_type", fmt: (v) => FIELD_TYPE_LABELS[v] ?? v },
+  { label: "Value Type", key: "value_type", fmt: (v) => VALUE_TYPE_LABELS[v] ?? v },
+  { label: "Group Key",  key: "group_key" },
+  { label: "Extra Key",  key: "extra_key" },
   { label: "Delimiter", key: "delimiter" },
 ];
 
@@ -690,8 +690,8 @@ const RulesPanel = memo(function RulesPanel({ row, validConditions, validActions
   onChangeDelimiter: (delimiter: string) => void;
   rowErrors: ValidationIssue[]; rowWarnings: ValidationIssue[];
 }) {
-  const isRemoved = row.state === "removed";
-  const isMulti   = row.type  === "multi_select";
+  const isRemoved = row.state      === "removed";
+  const isMulti   = row.field_type === "list";
   const defaultRule = (): ParseRule => ({ condition: "always", case_sensitive: false, action: "set", value: "" });
 
   function handleRuleChange(idx: number, patch: Partial<ParseRule>) {
@@ -774,10 +774,10 @@ const RulesPanel = memo(function RulesPanel({ row, validConditions, validActions
 // ─── Single mapping row ───────────────────────────────────────────────────────
 
 const MappingRowComponent = memo(function MappingRowComponent({
-  row, knownFields, validTypes, validConditions, validActions,
+  row, knownFields, validFieldTypes, validValueTypes, validConditions, validActions,
   onChange, isFirst, viewOnly, baselineLabel, errors, warnings, validationGeneration = 0,
 }: {
-  row: RichMappingRow; knownFields: string[]; validTypes: string[];
+  row: RichMappingRow; knownFields: string[]; validFieldTypes: string[]; validValueTypes: string[];
   validConditions: string[]; validActions: string[];
   onChange?: (patch: Partial<RichMappingRow>) => void;
   isFirst: boolean; viewOnly: boolean; baselineLabel: string;
@@ -785,8 +785,8 @@ const MappingRowComponent = memo(function MappingRowComponent({
   validationGeneration?: number;
 }) {
   const hasRules      = row.rules.length > 0;
-  const isRemoved     = row.state === "removed";
-  const isIgnored     = row.type === "ignore" || row.field === "__ignore__";
+  const isRemoved     = row.state      === "removed";
+  const isIgnored     = row.field_type === "ignore" || row.field === "__ignore__";
 
   const hasAliasEditor = !!(
     row.options &&
@@ -833,8 +833,8 @@ const MappingRowComponent = memo(function MappingRowComponent({
   const overRow     = useRef(false);
   const overTooltip = useRef(false);
 
-  const needsRowKey = row.type === "matrix_row";
-  const needsExtra  = row.field === "extra_data";
+  const needsGroupKey = row.field_type === "group";
+  const needsExtra    = row.field      === "extra_data";
   const colors      = ROW_COLORS[row.state];
   const badge       = BADGE_STYLES[row.state];
   const showDiff    = row.state === "changed";
@@ -920,16 +920,36 @@ const MappingRowComponent = memo(function MappingRowComponent({
 
   function handleFieldChange(field: string) {
     if (!onChange) return;
-    let type = row.type;
-    if (field === "__ignore__")                                           type = "ignore";
-    else if (field === "availability")                                    type = "matrix_row";
-    else if (type === "ignore")                                           type = "string";
-    onChange({ field, type, extra_key: field === "extra_data" ? row.extra_key : "" });
+    let field_type = row.field_type;
+    let value_type = row.value_type;
+    if (field === "__ignore__") {
+      field_type = "ignore";
+      value_type = "";
+    } else if (field === "availability" && field_type !== "group") {
+      field_type = "group";
+      value_type = "time_range";
+    } else if (field_type === "ignore") {
+      field_type = "single";
+      value_type = "text";
+    }
+    onChange({ field, field_type, value_type, extra_key: field === "extra_data" ? row.extra_key : "" });
   }
 
-  function handleTypeChange(type: string) {
+  function handleFieldTypeChange(field_type: string) {
     if (!onChange) return;
-    onChange({ type, ...(type === "ignore" ? { field: "__ignore__" } : {}) });
+    const patch: Partial<RichMappingRow> = { field_type };
+    if (field_type === "ignore") {
+      patch.field      = "__ignore__";
+      patch.value_type = "";
+    } else if (!row.value_type) {
+      patch.value_type = "text";
+    }
+    onChange(patch);
+  }
+
+  function handleValueTypeChange(value_type: string) {
+    if (!onChange) return;
+    onChange({ value_type });
   }
 
   const keyInputStyle: React.CSSProperties = { ...inputStyle, width: "100%", fontFamily: "var(--font-mono)", fontSize: "11px", opacity: isIgnored ? 0.5 : 1 };
@@ -937,20 +957,20 @@ const MappingRowComponent = memo(function MappingRowComponent({
   function renderKeyCell() {
     if (isRemoved) return <span style={{ fontFamily: "var(--font-sans)", fontSize: "11px", color: "var(--color-text-tertiary)", fontStyle: "italic" }}>excluded from save</span>;
 
-    if (!needsRowKey && !needsExtra) {
+    if (!needsGroupKey && !needsExtra) {
       return <span style={{ fontFamily: "var(--font-mono)", fontSize: "11px", color: "var(--color-text-tertiary)" }}>—</span>;
     }
 
     const labelStyle: React.CSSProperties = { fontFamily: "var(--font-sans)", fontSize: "9px", fontWeight: 600, textTransform: "uppercase" as const, letterSpacing: "0.06em", color: "var(--color-text-tertiary)", marginBottom: "2px" };
 
-    const both = needsRowKey && needsExtra;
+    const both = needsGroupKey && needsExtra;
 
-    const rowKeyEl = needsRowKey ? (
+    const groupKeyEl = needsGroupKey ? (
       <div style={both ? { flex: 1, minWidth: 0 } : {}}>
-        {both && <div style={labelStyle}>Row Key</div>}
+        {both && <div style={labelStyle}>Group Key</div>}
         {viewOnly
-          ? <span style={{ fontFamily: "var(--font-mono)", fontSize: "11px", color: "var(--color-text-secondary)" }}>{row.row_key || "—"}</span>
-          : <input style={keyInputStyle} placeholder="row_key name" value={row.row_key} onChange={(e) => onChange?.({ row_key: e.target.value })} />
+          ? <span style={{ fontFamily: "var(--font-mono)", fontSize: "11px", color: "var(--color-text-secondary)" }}>{row.group_key || "—"}</span>
+          : <input style={keyInputStyle} placeholder="group_key name" value={row.group_key} onChange={(e) => onChange?.({ group_key: e.target.value })} />
         }
       </div>
     ) : null;
@@ -966,9 +986,9 @@ const MappingRowComponent = memo(function MappingRowComponent({
     ) : null;
 
     if (both) {
-      return <div style={{ display: "flex", flexDirection: "row", gap: "6px", width: "100%" }}>{rowKeyEl}{extraKeyEl}</div>;
+      return <div style={{ display: "flex", flexDirection: "row", gap: "6px", width: "100%" }}>{groupKeyEl}{extraKeyEl}</div>;
     }
-    return rowKeyEl ?? extraKeyEl;
+    return groupKeyEl ?? extraKeyEl;
   }
 
   return (
@@ -979,7 +999,7 @@ const MappingRowComponent = memo(function MappingRowComponent({
         onMouseEnter={handleRowMouseEnter}
         onMouseLeave={handleRowMouseLeave}
         style={{
-          display: "grid", gridTemplateColumns: "1fr 160px 140px 1fr auto",
+          display: "grid", gridTemplateColumns: "1fr 160px 110px 110px 1fr auto",
           padding: "10px 14px", alignItems: "center", gap: "8px",
           background: rowBg,
           borderTop: isFirst ? "none" : "2px solid var(--color-border)",
@@ -1026,16 +1046,33 @@ const MappingRowComponent = memo(function MappingRowComponent({
           />
         )}
 
-        {/* Col 3: type — always editable (google_type lock removed) */}
+        {/* Col 3: field type */}
         {viewOnly ? (
           <span style={{ fontFamily: "var(--font-sans)", fontSize: "12px", color: "var(--color-text-secondary)" }}>
-            {TYPE_LABELS[row.type] ?? row.type}
+            {FIELD_TYPE_LABELS[row.field_type] ?? row.field_type}
           </span>
         ) : (
           <Select
-            value={row.type}
-            onChange={handleTypeChange}
-            options={validTypes.map((t) => ({ value: t, label: TYPE_LABELS[t] ?? t }))}
+            value={row.field_type}
+            onChange={handleFieldTypeChange}
+            options={validFieldTypes.map((t) => ({ value: t, label: FIELD_TYPE_LABELS[t] ?? t }))}
+            disabled={isRemoved}
+            size="sm"
+            background="var(--color-bg)"
+            fullWidth
+          />
+        )}
+
+        {/* Col 4: value type */}
+        {viewOnly ? (
+          <span style={{ fontFamily: "var(--font-sans)", fontSize: "12px", color: "var(--color-text-secondary)" }}>
+            {row.value_type ? (VALUE_TYPE_LABELS[row.value_type] ?? row.value_type) : "—"}
+          </span>
+        ) : (
+          <Select
+            value={row.value_type ?? ""}
+            onChange={handleValueTypeChange}
+            options={validValueTypes.map((t) => ({ value: t, label: VALUE_TYPE_LABELS[t] ?? t }))}
             disabled={isRemoved || isIgnored}
             size="sm"
             background="var(--color-bg)"
@@ -1201,7 +1238,7 @@ const MappingRowComponent = memo(function MappingRowComponent({
 // ─── Table wrapper ────────────────────────────────────────────────────────────
 
 export interface SheetConfigMappingTableProps {
-  rows: RichMappingRow[]; knownFields: string[]; validTypes: string[];
+  rows: RichMappingRow[]; knownFields: string[]; validFieldTypes: string[]; validValueTypes: string[];
   validConditions?: string[]; validActions?: string[];
   onChangeRow?: (idx: number, patch: Partial<RichMappingRow>) => void;
   viewOnly?: boolean; baselineLabel?: string;
@@ -1210,7 +1247,7 @@ export interface SheetConfigMappingTableProps {
 }
 
 export function SheetConfigMappingTable({
-  rows, knownFields, validTypes,
+  rows, knownFields, validFieldTypes, validValueTypes,
   validConditions = [], validActions = [],
   onChangeRow, viewOnly = false, baselineLabel = "suggestion",
   validationErrors = [], validationWarnings = [],
@@ -1224,8 +1261,8 @@ export function SheetConfigMappingTable({
 
   return (
     <div style={{ position: "relative", border: "1px solid var(--color-border)", borderRadius: "var(--radius-md)", overflow: "visible" }}>
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 160px 140px 1fr auto", alignItems: "start", padding: "8px 14px", background: "var(--color-bg)", borderBottom: "1px solid var(--color-border)", borderRadius: "var(--radius-md) var(--radius-md) 0 0", overflow: "hidden" }}>
-        {["Sheet Column", "Field", "Type", "Extra Key / Row Key", ""].map((h, i) => (
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 160px 110px 110px 1fr auto", alignItems: "start", padding: "8px 14px", background: "var(--color-bg)", borderBottom: "1px solid var(--color-border)", borderRadius: "var(--radius-md) var(--radius-md) 0 0", overflow: "hidden" }}>
+        {["Sheet Column", "Field", "Field Type", "Value Type", "Group Key / Extra Key", ""].map((h, i) => (
           <span key={i} style={{ fontFamily: "var(--font-sans)", fontSize: "10px", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.07em", color: "var(--color-text-tertiary)", whiteSpace: "normal", wordBreak: "break-word" }}>{h}</span>
         ))}
       </div>
@@ -1246,7 +1283,7 @@ export function SheetConfigMappingTable({
           return (
             <MappingRowComponent
               key={`${row.column_index}:${row.header}`} row={row}
-              knownFields={knownFields} validTypes={validTypes}
+              knownFields={knownFields} validFieldTypes={validFieldTypes} validValueTypes={validValueTypes}
               validConditions={validConditions} validActions={validActions}
               onChange={isViewOnly ? undefined : ((patch) => onChangeRow?.(idx, patch))}
               isFirst={idx === 0} viewOnly={isViewOnly}

--- a/frontend/components/ui/SheetConfigMappingTable.tsx
+++ b/frontend/components/ui/SheetConfigMappingTable.tsx
@@ -1050,10 +1050,7 @@ const MappingRowComponent = memo(function MappingRowComponent({
           <Select
             value={row.field_type}
             onChange={handleFieldTypeChange}
-            options={[
-              ...validFieldTypes.filter((t) => t !== "ignore").map((t) => ({ value: t, label: FIELD_TYPE_LABELS[t] ?? t })),
-              ...(isIgnored ? [{ value: "ignore", label: "Ignore" }] : []),
-            ]}
+            options={validFieldTypes.filter((t) => t !== "ignore").map((t) => ({ value: t, label: FIELD_TYPE_LABELS[t] ?? t }))}
             disabled={isRemoved || isIgnored}
             size="sm"
             background="var(--color-bg)"

--- a/frontend/components/ui/SheetConfigMappingTable.tsx
+++ b/frontend/components/ui/SheetConfigMappingTable.tsx
@@ -1259,7 +1259,7 @@ export function SheetConfigMappingTable({
 
   return (
     <div style={{ position: "relative", border: "1px solid var(--color-border)", borderRadius: "var(--radius-md)", overflow: "visible" }}>
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 160px 110px 110px 1fr auto", alignItems: "start", padding: "8px 14px", background: "var(--color-bg)", borderBottom: "1px solid var(--color-border)", borderRadius: "var(--radius-md) var(--radius-md) 0 0", overflow: "hidden" }}>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 160px 110px 110px 1fr auto", gap: "8px", alignItems: "start", padding: "8px 14px", background: "var(--color-bg)", borderBottom: "1px solid var(--color-border)", borderRadius: "var(--radius-md) var(--radius-md) 0 0", overflow: "hidden" }}>
         {["Sheet Column", "Field", "Field Type", "Value Type", "Group Key / Extra Key", ""].map((h, i) => (
           <span key={i} style={{ fontFamily: "var(--font-sans)", fontSize: "10px", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.07em", color: "var(--color-text-tertiary)", whiteSpace: "normal", wordBreak: "break-word" }}>{h}</span>
         ))}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -290,11 +290,11 @@ export interface FormQuestionOption {
   alias: string   // auto-suggested short version for DB storage
 }
 
+export type FieldType = 'single' | 'list' | 'group' | 'ignore'
+export type ValueType = 'text' | 'number' | 'boolean' | 'date' | 'time_range'
+
 export type ParseRuleCondition = 'always' | 'contains' | 'equals' | 'starts_with' | 'ends_with' | 'regex'
-export type ParseRuleAction    =
-  | 'set' | 'replace' | 'prepend' | 'append' | 'discard'
-  | 'parse_time_range'    // canonical action (backend refactor)
-  | 'parse_availability'  // legacy alias — kept for backwards compat
+export type ParseRuleAction    = 'set' | 'replace' | 'prepend' | 'append' | 'discard'
 
 export interface ParseRule {
   condition:      ParseRuleCondition
@@ -307,8 +307,9 @@ export interface ParseRule {
 
 export interface ColumnMapping {
   field:         string
-  type:          'string' | 'ignore' | 'boolean' | 'integer' | 'multi_select' | 'matrix_row'
-  row_key?:      string
+  field_type:    FieldType
+  value_type:    ValueType | null
+  group_key?:    string
   extra_key?:    string
   rules?:        ParseRule[]
   delimiter?:    string
@@ -336,8 +337,9 @@ export interface MappedHeader {
   column_index:  number
   header:        string             // raw column header from the sheet
   field:         string             // suggested target field
-  type:          string             // suggested mapping type
-  row_key?:      string
+  field_type:    FieldType         // suggested field type
+  value_type:    ValueType | null  // suggested value type
+  group_key?:    string
   extra_key?:    string
   rules?:        ParseRule[]
   delimiter?:    string
@@ -393,7 +395,8 @@ export interface SheetHeadersResponse {
   sheet_type:            string
   mappings:              MappedHeader[]
   known_fields:          string[]
-  valid_types:           string[]
+  valid_field_types:     string[]
+  valid_value_types:     string[]
   valid_rule_conditions: string[]
   valid_rule_actions:    string[]
 }

--- a/frontend/lib/importMappings.ts
+++ b/frontend/lib/importMappings.ts
@@ -4,13 +4,14 @@ import type { ColumnMappingEntry, ParseRule } from "@/lib/api";
 
 export interface MappingRow {
   column_index: number;
-  header:    string;
-  field:     string;
-  type:      string;
-  row_key:   string;
-  extra_key: string;
-  delimiter: string;           // only used when type === 'multi_select'; defaults to ''
-  rules:     ParseRule[];      // ordered list; empty array = no rules
+  header:     string;
+  field:      string;
+  field_type: string;
+  value_type: string;   // empty string when field_type === 'ignore'
+  group_key:  string;
+  extra_key:  string;
+  delimiter:  string;   // only used when field_type === 'list'; defaults to ''
+  rules:      ParseRule[];   // ordered list; empty array = no rules
 }
 
 export interface MappingsExport {
@@ -78,13 +79,19 @@ const KNOWN_FIELDS_LABELS: Record<string, string> = {
   "extra_data":          "Extra Data",
 };
 
-const TYPE_LABELS: Record<string, string> = {
-  string:       "Text",
-  ignore:       "Ignore",
-  boolean:      "Yes/No",
-  integer:      "Number",
-  multi_select: "Multi-select",
-  matrix_row:   "Matrix Row",
+const FIELD_TYPE_LABELS: Record<string, string> = {
+  single: "Single",
+  list:   "List",
+  group:  "Group",
+  ignore: "Ignore",
+};
+
+const VALUE_TYPE_LABELS: Record<string, string> = {
+  text:       "Text",
+  number:     "Number",
+  boolean:    "Yes / No",
+  date:       "Date",
+  time_range: "Time Range",
 };
 
 const CONDITION_LABELS: Record<string, string> = {
@@ -97,13 +104,11 @@ const CONDITION_LABELS: Record<string, string> = {
 };
 
 const ACTION_LABELS: Record<string, string> = {
-  set:               "Set to",
-  replace:           "Replace with",
-  prepend:           "Prepend",
-  append:            "Append",
-  discard:           "Discard",
-  parse_time_range:  "Parse time range",
-  parse_availability:"Parse availability",
+  set:     "Set to",
+  replace: "Replace with",
+  prepend: "Prepend",
+  append:  "Append",
+  discard: "Discard",
 };
 
 // ─── Rule description ─────────────────────────────────────────────────────────
@@ -134,11 +139,12 @@ export function describeRule(rule: ParseRule): string {
 export function mappingRowsEqual(a: MappingRow, b: MappingRow): boolean {
   if (
     a.column_index !== b.column_index ||
-    a.field     !== b.field     ||
-    a.type      !== b.type      ||
-    a.row_key   !== b.row_key   ||
-    a.extra_key !== b.extra_key ||
-    a.delimiter !== b.delimiter
+    a.field      !== b.field      ||
+    a.field_type !== b.field_type ||
+    a.value_type !== b.value_type ||
+    a.group_key  !== b.group_key  ||
+    a.extra_key  !== b.extra_key  ||
+    a.delimiter  !== b.delimiter
   ) return false;
 
   if (a.rules.length !== b.rules.length) return false;
@@ -163,11 +169,12 @@ function computeFieldDiffs(from: MappingRow, to: MappingRow): FieldDiff[] {
     toVal:   string;
     fmt?:    (v: string) => string;
   }> = [
-    { label: "Field",     fromVal: from.field,     toVal: to.field,     fmt: (v) => KNOWN_FIELDS_LABELS[v] ?? v },
-    { label: "Type",      fromVal: from.type,      toVal: to.type,      fmt: (v) => TYPE_LABELS[v] ?? v },
-    { label: "Row Key",   fromVal: from.row_key,   toVal: to.row_key },
-    { label: "Extra Key", fromVal: from.extra_key, toVal: to.extra_key },
-    { label: "Delimiter", fromVal: from.delimiter, toVal: to.delimiter },
+    { label: "Field",      fromVal: from.field,      toVal: to.field,      fmt: (v) => KNOWN_FIELDS_LABELS[v] ?? v },
+    { label: "Field Type", fromVal: from.field_type, toVal: to.field_type, fmt: (v) => FIELD_TYPE_LABELS[v] ?? v },
+    { label: "Value Type", fromVal: from.value_type, toVal: to.value_type, fmt: (v) => VALUE_TYPE_LABELS[v] ?? v },
+    { label: "Group Key",  fromVal: from.group_key,  toVal: to.group_key },
+    { label: "Extra Key",  fromVal: from.extra_key,  toVal: to.extra_key },
+    { label: "Delimiter",  fromVal: from.delimiter,  toVal: to.delimiter },
   ];
 
   const diffs: FieldDiff[] = [];
@@ -255,13 +262,14 @@ export function applyImport(
 
     const next: MappingRow = {
       column_index: row.column_index,
-      header:    row.header,
-      field:     m.field     ?? row.field,
-      type:      m.type      ?? row.type,
-      row_key:   m.row_key   ?? "",
-      extra_key: m.extra_key ?? "",
-      rules:     m.rules     ?? row.rules,
-      delimiter: m.delimiter ?? row.delimiter,
+      header:     row.header,
+      field:      m.field      ?? row.field,
+      field_type: m.field_type ?? row.field_type,
+      value_type: m.value_type ?? row.value_type,
+      group_key:  m.group_key  ?? "",
+      extra_key:  m.extra_key  ?? "",
+      rules:      m.rules      ?? row.rules,
+      delimiter:  m.delimiter  ?? row.delimiter,
     };
 
     if (!mappingRowsEqual(next, row)) {


### PR DESCRIPTION
Closes #26 

# Feat: Split mapping `type` into `field_type` + `value_type`

## Summary

- Splits the flat `type` field on `ColumnMapping` into two orthogonal fields: `field_type` (shape: `single`, `list`, `group`, `ignore`) and `value_type` (coercion: `text`, `number`, `boolean`, `date`, `time_range`)
- Renames `row_key` → `group_key` everywhere (schema, sync, suggestions, frontend)
- Removes `parse_time_range` / `parse_availability` as rule actions — time-range coercion is now expressed via `value_type="time_range"` on the mapping itself
- Adds a DB migration that translates all existing configs in place; no runtime legacy coercion needed after migration runs

## Backend changes

- **`schemas/sheet_config.py`** — `ColumnMapping` and `MappedHeader` use `field_type` + `value_type` + `group_key`; legacy `type`/`row_key` coerced on read via `coerce_legacy_mapping()`; `parse_time_range` rejected as a rule action
- **`services/sync_service.py`** — `_process_cell` dispatches on `field_type`/`value_type`; `time_range` coercion replaces the removed rule handler; `group_key` replaces `row_key`
- **`services/sheets_service.py`** — suggestions emit `field_type`/`value_type`/`group_key`; availability rows auto-get `value_type="time_range"`; `parse_time_range` auto-attach removed
- **`services/sheets_validation.py`** — validates new schema; rejects `parse_time_range`/`parse_availability` rule actions as errors
- **`alembic/versions/…_split_field_value_type.py`** — migrates all `column_mappings` JSON in place; irreversible

## Frontend changes

- **`lib/api.ts`** — adds `FieldType` / `ValueType` union types; `ColumnMapping`, `MappedHeader`, `SheetHeadersResponse` updated; `parse_time_range` removed from `ParseRuleAction`
- **`lib/importMappings.ts`** — `MappingRow` uses `field_type`/`value_type`/`group_key`; labels, equality check, diffs, and `applyImport` all updated
- **`SheetConfigMappingTable.tsx`** — single Type column split into Field Type + Value Type columns (6-column grid); `ignore` is not a selectable field type — it is set via the Field dropdown and locks both type columns; `group_key` input replaces `row_key`; `group_key` and `extra_key` inputs coexist when both conditions are met; `parse_time_range` removed from action labels
- **`sheets/new/page.tsx`**, **`sheets/[configId]/edit/page.tsx`**, **`sheets/[configId]/page.tsx`**, **`sheets/page.tsx`** — `emptyMappingRow`, `buildColumnMappings`, import handlers, and table props all updated

## Test plan

- [x] Run backend test suite: `pytest` — all 374 tests pass
- [x] Run `alembic upgrade head` against a dev DB with existing configs and verify `field_type`/`value_type`/`group_key` are correctly populated
- [x] Open the new-sheet wizard and confirm Field Type + Value Type dropdowns appear; set field to `__ignore__` and confirm both of the dropdowns in the type columns are disabled
- [x] Map an availability column as `group` / `time_range` and sync — verify slots are parsed correctly
- [x] Edit an existing config — confirm saved mappings load with correct `field_type`/`value_type`
- [x] Import a JSON export and confirm `applyImport` applies new fields correctly