### PR TITLE
feat/user email verification

### DIFF
--- a/backend/alembic/versions/f250cb93a643_add_email_verified.py
+++ b/backend/alembic/versions/f250cb93a643_add_email_verified.py
@@ -1,0 +1,26 @@
+"""add_email_verified
+
+Revision ID: f250cb93a643
+Revises: 2e1dda44cde5
+Create Date: 2026-06-28 22:31:08.365083
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f250cb93a643'
+down_revision: Union[str, None] = '2e1dda44cde5'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('email_verified', sa.Boolean(), nullable=False, server_default=sa.text('false')))
+
+
+def downgrade() -> None:
+    op.drop_column('users', 'email_verified')

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -149,10 +149,7 @@ def admin_register(body: AdminRegisterRequest, db: Session = Depends(get_db), _:
 
     return _create_user(db, body.email, body.first_name, body.last_name, body.role, is_active=False)
 
-@router.get(
-    "/auth/verify-email",
-    status_code=status.HTTP_200_OK,
-    response_model=MessageResponse,
+@router.get("/auth/verify-email/", status_code=status.HTTP_200_OK, response_model=MessageResponse,
     responses={
         400: {"description": "Invalid or expired token"},
         404: {"description": "User not found"},
@@ -169,10 +166,7 @@ def verify_email(token: str, db: Session = Depends(get_db)):
     return {"detail": "User email successfully verified"}
 
 # todo: add rate limiting
-@router.post(
-    "/auth/send-email-verification",
-    status_code=status.HTTP_200_OK,
-    response_model=MessageResponse,
+@router.post("/auth/send-email-verification/", status_code=status.HTTP_200_OK, response_model=MessageResponse,
     responses={
         400: {"description": "Email already verified"},
         500: {"description": "Failed to send verification email"},

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -176,6 +176,6 @@ async def send_email_verification(user: User = Depends(get_current_user)):
     if user.email_verified:
         raise HTTPException(400, "Email already verified")
     
-    await _send_verification_email(user.email, user.id)
+    # await _send_verification_email(user.email, user.id)
 
     return {"detail": "Verification email successfully sent"}

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -15,7 +15,7 @@ from app.core.email_verification import generate_verification_token, verify_veri
 from app.db.session import get_db
 from app.models.models import User
 from app.schemas.user import UserResponse
-from app.schemas.auth import LoginRequest, RegisterRequest, AdminRegisterRequest
+from app.schemas.auth import LoginRequest, RegisterRequest, AdminRegisterRequest, MessageResponse
 from app.services.email_service import send_verification_email
 
 router = APIRouter( tags=["auth"])
@@ -79,7 +79,7 @@ async def _send_verification_email(to: str, id: int):
         await send_verification_email(to, generate_verification_token(id))
 
     except Exception:
-        raise HTTPException(500, "Failed to send verification email.")
+        raise HTTPException(500, "Failed to send verification email")
 
 
 @router.post("/auth/login/", response_model=UserResponse)
@@ -149,11 +149,19 @@ def admin_register(body: AdminRegisterRequest, db: Session = Depends(get_db), _:
 
     return _create_user(db, body.email, body.first_name, body.last_name, body.role, is_active=False)
 
-@router.get("/auth/verify-email", status_code=status.HTTP_200_OK)
+@router.get(
+    "/auth/verify-email",
+    status_code=status.HTTP_200_OK,
+    response_model=MessageResponse,
+    responses={
+        400: {"description": "Invalid or expired token"},
+        404: {"description": "User not found"},
+    },
+)
 def verify_email(token: str, db: Session = Depends(get_db)):
     user_id = verify_verification_token(token)
     if user_id is None:
-        raise HTTPException(400, "Email verification is invalid or has expired.")
+        raise HTTPException(400, "Invalid or expired token")
     
     user = find_user_by_id(db, user_id)
     user.email_verified = True
@@ -161,11 +169,19 @@ def verify_email(token: str, db: Session = Depends(get_db)):
     return {"detail": "User email successfully verified"}
 
 # todo: add rate limiting
-@router.post("/auth/send-email-verification", status_code=status.HTTP_200_OK)
-async def resend_email_verification(user: User = Depends(get_current_user)):
+@router.post(
+    "/auth/send-email-verification",
+    status_code=status.HTTP_200_OK,
+    response_model=MessageResponse,
+    responses={
+        400: {"description": "Email already verified"},
+        500: {"description": "Failed to send verification email"},
+    },
+)
+async def send_email_verification(user: User = Depends(get_current_user)):
     if user.email_verified:
-        raise HTTPException(400, "User email already verified.")
+        raise HTTPException(400, "Email already verified")
     
     await _send_verification_email(user.email, user.id)
 
-    return {"detail": "Verification email successfully sent."}
+    return {"detail": "Verification email successfully sent"}

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -10,11 +10,13 @@ from app.core.auth import (
     require_admin,
 )
 from app.core.config import get_settings
-from app.core.users import check_if_email_exists
+from app.core.users import check_if_email_exists, find_user_by_id
+from app.core.email_verification import generate_verification_token, verify_verification_token
 from app.db.session import get_db
 from app.models.models import User
 from app.schemas.user import UserResponse
 from app.schemas.auth import LoginRequest, RegisterRequest, AdminRegisterRequest
+from app.services.email_service import send_verification_email
 
 router = APIRouter( tags=["auth"])
 
@@ -72,6 +74,13 @@ def _create_user(
     db.refresh(user)
     return user
     
+async def _send_verification_email(to: str, id: int):
+    try:
+        await send_verification_email(to, generate_verification_token(id))
+
+    except Exception:
+        raise HTTPException(500, "Failed to send verification email.")
+
 
 @router.post("/auth/login/", response_model=UserResponse)
 def login(body: LoginRequest, response: Response, db: Session = Depends(get_db)):
@@ -139,3 +148,24 @@ def admin_register(body: AdminRegisterRequest, db: Session = Depends(get_db), _:
     check_if_email_exists(db, body.email)
 
     return _create_user(db, body.email, body.first_name, body.last_name, body.role, is_active=False)
+
+@router.get("/auth/verify-email", status_code=status.HTTP_200_OK)
+def verify_email(token: str, db: Session = Depends(get_db)):
+    user_id = verify_verification_token(token)
+    if user_id is None:
+        raise HTTPException(400, "Email verification is invalid or has expired.")
+    
+    user = find_user_by_id(db, user_id)
+    user.email_verified = True
+    db.commit()
+    return {"detail": "User email successfully verified"}
+
+# todo: add rate limiting
+@router.post("/auth/send-email-verification", status_code=status.HTTP_200_OK)
+async def resend_email_verification(user: User = Depends(get_current_user)):
+    if user.email_verified:
+        raise HTTPException(400, "User email already verified.")
+    
+    await _send_verification_email(user.email, user.id)
+
+    return {"detail": "Verification email successfully sent."}

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -4,19 +4,12 @@ from sqlalchemy.orm import Session
 
 from app.core.auth import get_current_user, require_admin
 from app.core.permissions import MANAGE_TOURNAMENT, MANAGE_VOLUNTEERS, has_permission
-from app.core.users import check_if_email_exists
+from app.core.users import check_if_email_exists, find_user_by_id
 from app.db.session import get_db
 from app.models.models import Membership, User
 from app.schemas.user import UserResponse, UserUpdate, AdminUserUpdate
 
 router = APIRouter(tags=["users"])
-
-def _find_user_by_id(db: Session, id: int) -> User:
-    user = db.query(User).filter(User.id == id).first()
-    if not user:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
-    return user
-
 
 
 # ---------------------------------------------------------------------------
@@ -74,7 +67,7 @@ def admin_update_user(
     _: User = Depends(require_admin)
 ):
     """Admin can only update a user's role and is_active status."""
-    user = _find_user_by_id(db, user_id)
+    user = find_user_by_id(db, user_id)
     for field, value in body.model_dump(exclude_unset=True).items():
         setattr(user, field, value)
     db.commit()

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -46,7 +46,7 @@ ACCESS_TOKEN_EXPIRE_DAYS = 7
 def create_access_token(user_id: int) -> str:
     settings = get_settings()
     expire = datetime.now(timezone.utc) + timedelta(days=ACCESS_TOKEN_EXPIRE_DAYS)
-    payload = {"sub": str(user_id), "exp": expire}
+    payload = {"sub": str(user_id), "exp": expire, "aud": "session"}
     return jwt.encode(payload, settings.jwt_secret, algorithm=ALGORITHM)
 
 
@@ -54,7 +54,7 @@ def decode_access_token(token: str) -> Optional[int]:
     """Returns user_id from a valid token, or None if invalid/expired."""
     settings = get_settings()
     try:
-        payload = jwt.decode(token, settings.jwt_secret, algorithms=[ALGORITHM])
+        payload = jwt.decode(token, settings.jwt_secret, algorithms=[ALGORITHM], audience="session")
         user_id = payload.get("sub")
         if user_id is None:
             return None

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -10,15 +10,18 @@ class Settings(BaseSettings):
     app_host: str = "0.0.0.0"
     app_port: int = 8000
 
-    database_url: str = "sqlite:///./nexus.db"
+    database_url: str = "postgresql://nexus:nexus@127.0.0.1:5432/nexus"
 
     google_service_account_file: str = "./credentials.json"
     google_service_account_json: str = ""  # JSON string — used in production instead of file
 
     api_key: str = ""  # For direct API access / Swagger only
 
-    # Must be set to a long random string in production — never commit the real value
+    # Must be set to a long random string in production
     jwt_secret: str = "dev-secret-change-in-production"
+
+    resend_api_key: str = "" # set in .env file for dev or env vars in prod, never commit here
+    frontend_url: str = "http://localhost:3000/" # remember to set to actual url in prod
 
 
 @lru_cache()

--- a/backend/app/core/email_verification.py
+++ b/backend/app/core/email_verification.py
@@ -1,0 +1,27 @@
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from jose import JWTError, jwt
+
+from app.core.config import get_settings
+
+ALGORITHM = "HS256"
+VERIFICATION_TOKEN_EXPIRE_DAYS = 1
+
+def generate_verification_token(user_id: int) -> str:
+    settings = get_settings()
+    expire = datetime.now(timezone.utc) + timedelta(days=VERIFICATION_TOKEN_EXPIRE_DAYS)
+    payload = {"sub": str(user_id), "exp": expire, "aud": "email_verification"}
+    return jwt.encode(payload, settings.jwt_secret, algorithm=ALGORITHM)
+
+def verify_verification_token(token: str) -> Optional[int]:
+    """Returns user_id if valid token, or None if invalid/expired/wrong purpose"""
+    settings = get_settings()
+    try:
+        payload = jwt.decode(token, settings.jwt_secret, algorithms=[ALGORITHM], audience="email_verification")
+        user_id = payload.get("sub")
+        if user_id is None:
+            return None
+        return int(user_id)
+    except JWTError:
+        return None

--- a/backend/app/core/users.py
+++ b/backend/app/core/users.py
@@ -10,3 +10,10 @@ def check_if_email_exists(db: Session, email: str):
             status_code=status.HTTP_409_CONFLICT,
             detail="Email already registered",
         )
+    
+
+def find_user_by_id(db: Session, id: int) -> User:
+    user = db.query(User).filter(User.id == id).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    return user

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -91,6 +91,7 @@ class User(Base):
 
     # Auth fields
     hashed_password = Column(String(255), nullable=True)   # null = cannot log in, must reset password and verify via email
+    email_verified = Column(Boolean, nullable=False, default=False)
     role = Column(String(32), nullable=False, default="user")  # "admin" | "user"
     is_active = Column(Boolean, nullable=False, default=True)
     

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -76,3 +76,7 @@ class AdminRegisterRequest(BaseModel):
     first_name: str
     last_name: str
     role: Literal["admin", "user"]
+
+
+class MessageResponse(BaseModel):
+    detail: str

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -53,6 +53,7 @@ class UserResponse(BaseModel):
     email: EmailStr
     phone: Optional[str] = None
 
+    email_verified: bool
     role: ROLE
     is_active: bool
     

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -8,7 +8,7 @@ async def send_verification_email(to: str, token: str) -> None:
     resend.api_key = settings.resend_api_key
     
     params: resend.Emails.SendParams = {
-        "from": "NEXUS <no-reply@nexus.ethanshih.com>",
+        "from": "NEXUS <verify@nexus.ethanshih.com>",
         "to": to,
         "subject": "Verify Your Email on NEXUS",
         "text": f"Please verify your email: {settings.frontend_url.rstrip('/')}/verify-email?token={token}"

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -1,0 +1,17 @@
+import resend
+
+from app.core.config import get_settings
+
+
+async def send_verification_email(to: str, token: str) -> None:
+    settings = get_settings()
+    resend.api_key = settings.resend_api_key
+    
+    params: resend.Emails.SendParams = {
+        "from": "NEXUS <no-reply@nexus.ethanshih.com>",
+        "to": to,
+        "subject": "Verify Your Email on NEXUS",
+        "text": f"Please verify your email: {settings.frontend_url.rstrip('/')}/verify-email?token={token}"
+    }
+
+    resend.Emails.send_async(params)

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -14,4 +14,4 @@ async def send_verification_email(to: str, token: str) -> None:
         "text": f"Please verify your email: {settings.frontend_url.rstrip('/')}/verify-email?token={token}"
     }
 
-    resend.Emails.send_async(params)
+    await resend.Emails.send_async(params)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -28,6 +28,9 @@ google-auth==2.37.0
 google-auth-oauthlib==1.2.1
 google-api-python-client==2.154.0
 
+# Resend (email services) API
+resend==2.32.2
+
 # Testing
 pytest==8.3.4
 pytest-asyncio==0.24.0

--- a/frontend/app/(auth)/sign-up/page.tsx
+++ b/frontend/app/(auth)/sign-up/page.tsx
@@ -60,6 +60,20 @@ function clearCookie() {
   document.cookie = "inSignUpFlow=; path=/; max-age=0"
 }
 
+const STATE = {
+  ACCOUNT: 1,
+  STUDENT_STATUS: 2,
+  UNIVERSITY: 3,
+  EMPLOYER: 4,
+  COMPETED_BEFORE: 5,
+  COMPETITION_EXP: 6,
+  VOLUNTEERED_BEFORE: 7,
+  VOLUNTEERING_EXP: 8,
+  SHIRT_SIZE: 9,
+  DIETARY_RESTRICTIONS: 10,
+  DIETARY_TEXT: 11,
+  COMPLETE: 12,
+} as const
 
 export default function SignUpPage() {
   // ── Sign-up step states ──────────────────────────────────────────────────
@@ -76,7 +90,7 @@ export default function SignUpPage() {
   // 11  Dietary restriction text
   // 12  Complete button activated
   // ────────────────────────────────────────────────────────────────────────
-  const [state, setState] = useState(1)
+  const [state, setState] = useState<number>(STATE.ACCOUNT)
   const [user, setUser] = useState<User | null>(null)
   const [loading, setLoading] = useState(false)
 
@@ -144,7 +158,7 @@ export default function SignUpPage() {
     authApi.me().then(user => {
       if (document.cookie.includes("inSignUpFlow")) {
         setUser(user)
-        setState(2)
+        setState(STATE.STUDENT_STATUS)
       } else {
         router.push('/dashboard')
       }
@@ -182,7 +196,7 @@ export default function SignUpPage() {
 
       setCookie()
 
-      setState(2)
+      setState(STATE.STUDENT_STATUS)
     } catch (error: unknown) {
       if (error instanceof ApiError) {
         setErrors({ form1: error.message })
@@ -242,7 +256,7 @@ export default function SignUpPage() {
 
   return (
     <>
-      {state === 1 && (
+      {state === STATE.ACCOUNT && (
           <section style={{ maxWidth: '420px', width: '100%' }}>
           <div style={{ marginBottom: '5px' }}>
             <button onClick={() => router.push('/')} className="link-subtle" style={{
@@ -272,7 +286,7 @@ export default function SignUpPage() {
             }}>Sign Up</h2>
           </div>
 
-          <form onSubmit={handleRegisterSubmit} noValidate style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+          <form onSubmit={handleRegisterSubmit} noValidate style={{ display: 'flex', flexDirection: 'column', gap: '15px' }}>
             <Input
               label="First Name"
               type="text"
@@ -365,11 +379,7 @@ export default function SignUpPage() {
 
             <div>
               {errors.form1 && (
-                <p style={{
-                  fontFamily: 'var(--font-sans)',
-                  fontSize: '14px',
-                  color: 'var(--color-danger)'
-                }}>
+                <p style={{ fontFamily: 'var(--font-sans)', fontSize: '14px', color: 'var(--color-danger)' }}>
                   {errors.form1}
                 </p>
               )}
@@ -378,7 +388,7 @@ export default function SignUpPage() {
         </section>
       )}
 
-      {state >= 2 && (
+      {state >= STATE.STUDENT_STATUS && (
         <section style={{ maxWidth: '600px', width: '100%', margin: '20px 0px'}}>
           <div style={{ marginBottom: '10px' }}>
             <h1 style={{
@@ -396,21 +406,21 @@ export default function SignUpPage() {
               color: 'var(--color-text-primary)'
             }}>Complete Your Profile</h2>
           </div>
-          
+
           <form onSubmit={handleProfileSubmit} noValidate>
             <ProfileQuestion
               question="What is your student status?"
-              onSkip={() => setState(5)}
-              isActive={state === 2}
+              onSkip={() => setState(STATE.STUDENT_STATUS + 3)}
+              isActive={state === STATE.STUDENT_STATUS}
             ><Select
                 value={profileData.student_status ?? ''}
                 onChange={v => {
                   setProfileData(d => ({...d, student_status: v as STUDENT_STATUS}))
-                  if (state >= 5) return
+                  if (state >= (STATE.STUDENT_STATUS + 3)) return
                   if (v === 'Undergraduate' || v === 'Graduate') {
-                    setState(3)
+                    setState(STATE.UNIVERSITY)
                   } else if (v === 'Non-Student') {
-                    setState(4)
+                    setState(STATE.EMPLOYER)
                   }
                 }}
                 options={[
@@ -421,8 +431,8 @@ export default function SignUpPage() {
                 fullWidth
               />
             </ProfileQuestion>
-            
-            { state >= 3 && (profileData.student_status === "Undergraduate" || profileData.student_status === "Graduate") && (
+
+            { state >= STATE.UNIVERSITY && (profileData.student_status === "Undergraduate" || profileData.student_status === "Graduate") && (
               <div>
                 <ProfileQuestion question="What university do you attend?">
                   <Input
@@ -468,7 +478,7 @@ export default function SignUpPage() {
                   question="What is your projected graduation year?"
                   onSkip={() => {
                     setProfileData(d => ({...d, university: undefined, major: undefined, year_level: undefined, graduation_year: undefined}))
-                    setState(5)
+                    setState(STATE.UNIVERSITY + 2)
                   }}
                   onNext={() => {
                     const ers: typeof errors = {}
@@ -481,9 +491,9 @@ export default function SignUpPage() {
                     else if (profileData.graduation_year < 1000 || profileData.graduation_year > 9999)
                       ers.graduation_year = "Must be a valid year."
 
-                    Object.keys(ers).length > 0 ? setErrors(er => ({...er, ...ers})) : setState(5)
+                    Object.keys(ers).length > 0 ? setErrors(er => ({...er, ...ers})) : setState(STATE.UNIVERSITY + 2)
                   }}
-                  isActive={state === 3}
+                  isActive={state === STATE.UNIVERSITY}
                 ><Input
                       type="text"
                       value={profileData.graduation_year}
@@ -499,14 +509,14 @@ export default function SignUpPage() {
               </div>
             )}
 
-            {state >= 4 && profileData.student_status === "Non-Student" && (
+            {state >= STATE.EMPLOYER && profileData.student_status === "Non-Student" && (
               <ProfileQuestion
                 question="Who is your employer?"
-                onSkip={() => setState(5)}
+                onSkip={() => setState(STATE.COMPETED_BEFORE)}
                 onNext={() => {
-                  !profileData.employer ? setErrors(er => ({...er, employer: "Cannot be empty."})) : setState(5)
+                  !profileData.employer ? setErrors(er => ({...er, employer: "Cannot be empty."})) : setState(STATE.COMPETED_BEFORE)
                 }}
-                isActive={state === 4}
+                isActive={state === STATE.EMPLOYER}
               ><Input
                     type="text"
                     value={profileData.employer}
@@ -519,35 +529,35 @@ export default function SignUpPage() {
               </ProfileQuestion>
             )}
 
-            {state >= 5 && (
+            {state >= STATE.COMPETED_BEFORE && (
               <ProfileQuestion
                 question="Have you competed in Science Olympiad before?"
                 onSkip={() => {
-                  setState(7)
+                  setState(STATE.COMPETED_BEFORE + 2)
                 }}
-                isActive={state === 5}
+                isActive={state === STATE.COMPETED_BEFORE}
               ><div style={{ display: 'flex', gap: '8px' }}>
-                <RadioOption 
+                <RadioOption
                   name="competed"
                   value="yes"
                   checked={competedBefore === true}
                   onChange={() => {
                     setCompetedBefore(true)
-                    if (state >= 7) return
-                    setState(6)
+                    if (state >= STATE.COMPETED_BEFORE + 2) return
+                    setState(STATE.COMPETITION_EXP)
                   }}
                   label="Yes"
                   showCircle={false}
                   solid
                 />
-                <RadioOption 
+                <RadioOption
                   name="competed"
                   value="no"
                   checked={competedBefore === false}
-                  onChange={() => { 
+                  onChange={() => {
                     setCompetedBefore(false)
-                    if (state >= 7) return
-                    setState(7) 
+                    if (state >= STATE.COMPETED_BEFORE + 2) return
+                    setState(STATE.COMPETED_BEFORE + 2)
                   }}
                   label="No"
                   showCircle={false}
@@ -557,18 +567,18 @@ export default function SignUpPage() {
               </ProfileQuestion>
             )}
 
-            {state >= 6 && competedBefore && (
+            {state >= STATE.COMPETITION_EXP && competedBefore && (
               <ProfileQuestion
                 question="List your competition experience."
                 onSkip={() => {
                   setCompetedBefore(null)
-                  setState(7)
+                  setState(STATE.VOLUNTEERED_BEFORE)
                 }}
                 onNext={() => {
                   !profileData.competition_exp ? setErrors(er => ({...er, competition_exp: "Cannot be empty."}))
-                    : setState(7)
+                    : setState(STATE.VOLUNTEERED_BEFORE)
                 }}
-                isActive={state === 6}
+                isActive={state === STATE.COMPETITION_EXP}
               ><Textarea
                     value={profileData.competition_exp}
                     onChange={e => {
@@ -580,35 +590,35 @@ export default function SignUpPage() {
               </ProfileQuestion>
             )}
 
-            {state >= 7 && (
+            {state >= STATE.VOLUNTEERED_BEFORE && (
               <ProfileQuestion
                 question="Have you volunteered for Science Olympiad before?"
                 onSkip={() => {
-                  setState(9)
+                  setState(STATE.SHIRT_SIZE)
                 }}
-                isActive={state === 7}
+                isActive={state === STATE.VOLUNTEERED_BEFORE}
               ><div style={{ display: 'flex', gap: '8px' }}>
-                <RadioOption 
+                <RadioOption
                   name="volunteered"
                   value="yes"
                   checked={volunteeredBefore === true}
                   onChange={() => {
                     setVolunteeredBefore(true)
-                    if (state >= 9) return
-                    setState(8)
+                    if (state >= STATE.SHIRT_SIZE) return
+                    setState(STATE.VOLUNTEERING_EXP)
                   }}
                   label="Yes"
                   showCircle={false}
                   solid
                 />
-                <RadioOption 
+                <RadioOption
                   name="volunteered"
                   value="no"
                   checked={volunteeredBefore === false}
                   onChange={() => {
                     setVolunteeredBefore(false)
-                    if (state >= 9) return
-                    setState(9) 
+                    if (state >= STATE.SHIRT_SIZE) return
+                    setState(STATE.SHIRT_SIZE)
                   }}
                   label="No"
                   showCircle={false}
@@ -618,18 +628,18 @@ export default function SignUpPage() {
               </ProfileQuestion>
             )}
 
-            {state >= 8 && volunteeredBefore && (
+            {state >= STATE.VOLUNTEERING_EXP && volunteeredBefore && (
               <ProfileQuestion
                 question="List your volunteer experience."
                 onSkip={() => {
                   setVolunteeredBefore(null)
-                  setState(9)
+                  setState(STATE.SHIRT_SIZE)
                 }}
                 onNext={() => {
                   !profileData.volunteering_exp ? setErrors(er => ({...er, volunteering_exp: "Cannot be empty."}))
-                    : setState(9)
+                    : setState(STATE.SHIRT_SIZE)
                 }}
-                isActive={state === 8}
+                isActive={state === STATE.VOLUNTEERING_EXP}
               ><Textarea
                     value={profileData.volunteering_exp}
                     onChange={e => {
@@ -641,24 +651,24 @@ export default function SignUpPage() {
               </ProfileQuestion>
             )}
 
-            {state >= 9 && (
+            {state >= STATE.SHIRT_SIZE && (
               <ProfileQuestion
                 question="What is your shirt size?"
                 onSkip={() => {
                   setProfileData(d => ({...d, shirt_size: undefined}))
-                  setState(10)
+                  setState(STATE.DIETARY_RESTRICTIONS)
                 }}
-                isActive={state === 9}
+                isActive={state === STATE.SHIRT_SIZE}
               ><div style={{ display: 'flex', gap: '8px' }}>
                 {["XS", "S", "M", "L", "XL", "XXL"].map(size => (
-                  <RadioOption 
+                  <RadioOption
                     name="shirt"
                     value={size}
                     key={size}
                     checked={profileData.shirt_size === size}
                     onChange={() => {
                       setProfileData(d => ({...d, shirt_size: size as SHIRT_SIZE}))
-                      if (state === 9) setState(10)
+                      if (state === STATE.SHIRT_SIZE) setState(STATE.DIETARY_RESTRICTIONS)
                     }}
                     label={size}
                     showCircle={false}
@@ -669,35 +679,35 @@ export default function SignUpPage() {
               </ProfileQuestion>
             )}
 
-            {state >= 10 && (
+            {state >= STATE.DIETARY_RESTRICTIONS && (
               <ProfileQuestion
                 question="Do you have any dietary restrictions?"
                 onSkip={() => {
-                  setState(12)
+                  setState(STATE.COMPLETE)
                 }}
-                isActive={state === 10}
+                isActive={state === STATE.DIETARY_RESTRICTIONS}
               ><div style={{ display: 'flex', gap: '8px' }}>
-                <RadioOption 
+                <RadioOption
                   name="dietary"
                   value="yes"
                   checked={hasDietary === true}
                   onChange={() => {
                     setHasDietary(true)
-                    if (state >= 12) return
-                    setState(11)
+                    if (state >= STATE.COMPLETE) return
+                    setState(STATE.DIETARY_TEXT)
                   }}
                   label="Yes"
                   showCircle={false}
                   solid
                 />
-                <RadioOption 
+                <RadioOption
                   name="dietary"
                   value="no"
                   checked={hasDietary === false}
                   onChange={() => {
                     setHasDietary(false)
-                    if (state >= 12) return
-                    setState(12) 
+                    if (state >= STATE.COMPLETE) return
+                    setState(STATE.COMPLETE)
                   }}
                   label="No"
                   showCircle={false}
@@ -707,18 +717,18 @@ export default function SignUpPage() {
               </ProfileQuestion>
             )}
 
-            {state >= 11 && hasDietary && (
+            {state >= STATE.DIETARY_TEXT && hasDietary && (
               <ProfileQuestion
                 question="List your dietary restrictions."
                 onSkip={() => {
                   setHasDietary(null)
-                  setState(12)
+                  setState(STATE.COMPLETE)
                 }}
                 onNext={() => {
                   !profileData.dietary_restriction ? setErrors(er => ({...er, dietary_restriction: "Cannot be empty."}))
-                    : setState(12)
+                    : setState(STATE.COMPLETE)
                 }}
-                isActive={state === 11}
+                isActive={state === STATE.DIETARY_TEXT}
               ><Textarea
                     value={profileData.dietary_restriction}
                     onChange={e => {
@@ -742,7 +752,7 @@ export default function SignUpPage() {
                 type="submit"
                 variant="primary"
                 size="lg"
-                disabled={state !== 12}
+                disabled={state !== STATE.COMPLETE}
                 loading={loading}
                 fullWidth
               >Complete</Button>

--- a/frontend/app/(auth)/sign-up/page.tsx
+++ b/frontend/app/(auth)/sign-up/page.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/Button"
 import { Select } from "@/components/ui/Select"
 import { RadioOption } from "@/components/ui/RadioOption"
 import { Textarea } from "@/components/ui/Textarea"
+import { Modal } from "@/components/ui/Modal"
 
 
 
@@ -109,6 +110,7 @@ export default function SignUpPage() {
     confirm: boolean
   }>({ length: false, upper: false, lower: false, number: false, symbol: false, confirm: false })
 
+  const [showVerifyModal, setShowVerifyModal] = useState(false)
 
   const [profileData, setProfileData] = useState<{
     student_status?: STUDENT_STATUS
@@ -196,7 +198,9 @@ export default function SignUpPage() {
 
       setCookie()
 
-      setState(STATE.STUDENT_STATUS)
+      authApi.sendEmailVerification().then(() => {
+        setShowVerifyModal(true)
+      }).catch(() => {}).finally(() => setState(STATE.STUDENT_STATUS))
     } catch (error: unknown) {
       if (error instanceof ApiError) {
         setErrors({ form1: error.message })
@@ -206,6 +210,21 @@ export default function SignUpPage() {
     } finally {
       setLoading(false)
     }
+  }
+
+  function VerifyModal() {
+    return (
+      <Modal onClose={() => {}}>
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center' }}>
+          <IconCheckCircleSolid style={{ color: 'var(--color-success)', marginBottom: '20px' }} size={72} />
+          <h2 style={{ fontFamily: 'var(--font-serif)', fontSize: '22px', color: 'var(--color-text-primary)', marginBottom: '10px' }}>
+            Your account was created successfully
+          </h2>
+          <p style={{ fontFamily: 'var(--font-sans)', fontSize: '14px', marginBottom: '10px' }}>We sent a verification link to {user?.email ?? email}</p>
+          <Button fullWidth onClick={() => setShowVerifyModal(false)}>Got it!</Button>
+        </div>
+      </Modal>
+    )
   }
 
   async function handleProfileSubmit(e: React.SyntheticEvent) {
@@ -390,6 +409,8 @@ export default function SignUpPage() {
 
       {state >= STATE.STUDENT_STATUS && (
         <section style={{ maxWidth: '600px', width: '100%', margin: '20px 0px'}}>
+          {showVerifyModal && <VerifyModal />}
+
           <div style={{ marginBottom: '10px' }}>
             <h1 style={{
               fontFamily: 'var(--font-serif)',

--- a/frontend/app/(auth)/verify-email/page.tsx
+++ b/frontend/app/(auth)/verify-email/page.tsx
@@ -1,0 +1,134 @@
+'use client'
+
+import { Button } from "@/components/ui/Button"
+import { IconCheckCircleSolid, IconXCircleSolid } from "@/components/ui/Icons"
+import { Spinner } from "@/components/ui/Spinner"
+import { ApiError, authApi, User } from "@/lib/api"
+import { useRouter, useSearchParams } from "next/navigation"
+import { Suspense, useEffect, useState } from "react"
+
+
+export default function VerifyEmailPage() {
+  return (
+    <Suspense fallback={<Spinner size='lg' />}>
+      <VerifyEmailContent />
+    </Suspense>
+  )
+}
+
+function VerifyEmailContent() {
+  // ── Verify Email states ──────────────────────────────────────────────────
+  //  1  Loading
+  //  2  Success
+  //  3  Error
+  // ────────────────────────────────────────────────────────────────────────
+  const [state, setState] = useState<number>(1)
+  const [user, setUser] = useState<User | null>(null)
+  const [sendEmailSuccess, setSendEmailSuccess] = useState<boolean>(false)
+  const [loading, setLoading] = useState<boolean>(false)
+  const [errors, setErrors] = useState<{
+    verify?: string
+    send?: string
+  }>({})
+
+  const searchParams = useSearchParams()
+  const token = searchParams.get("token")
+
+  const router = useRouter()
+
+  useEffect(() => {
+    
+    authApi.me().then(u => setUser(u)).catch(() => {})
+
+    authApi.verifyEmail(token ?? '').then(() => setState(2)).catch(err => {
+      const message = err instanceof ApiError ? err.message : "Something went wrong"
+      setErrors({verify: message})
+      setState(3)
+    })
+    
+  }, [])
+
+  return (
+    <section style={{
+      background: 'var(--color-surface)',
+      padding: '100px 0',
+      borderRadius: '10px',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      width: '100%',
+      maxWidth: 'min(420px, 90vw)',
+      boxShadow: 'var(--shadow-lg)',
+    }}>
+      <div style={{ marginBottom: '10px' }}>
+        <h1 style={{
+          fontFamily: 'var(--font-serif)',
+          fontSize: '48px',
+          color: 'var(--color-text-primary)'
+        }}>NEXUS</h1>
+      </div>
+
+      <div style={{ marginBottom: '30px' }}>
+        <h2 style={{
+          fontFamily: 'var(--font-sans)',
+          fontSize: '28px',
+          fontWeight: '700',
+          color: 'var(--color-text-primary)'
+        }}>Verify Your Email</h2>
+      </div>
+
+      {state === 1 && (
+        <Spinner size='lg' />
+      )}
+
+      {state === 2 && (
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+          <span style={{ marginBottom: '10px', display: 'flex', gap: '5px', alignItems: 'center', fontFamily: 'var(--font-sans)', fontSize: '16px', color: 'var(--color-text-primary)' }}>
+              <IconCheckCircleSolid style={{ color: 'var(--color-success)'}} size={16} />Email successfully verified.
+          </span>
+          {user ? (
+            <Button onClick={() => router.push('/dashboard')}>Go to Dashboard</Button>
+          ) : (
+            <span style={{ fontFamily: 'var(--font-sans)', fontSize: '12px', color: 'var(--color-text-secondary)' }}>
+                You can close this window.
+            </span>
+          )}
+        </div>
+      )}
+
+      {state === 3 && (
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center'}}>
+          <span style={{ marginBottom: '10px', alignItems: 'center', display: 'flex', gap: '6px', fontFamily: 'var(--font-sans)', fontSize: '16px', color: 'var(--color-text-primary)' }}>
+              <IconXCircleSolid style={{ color: 'var(--color-danger)'}} size={16} />Error: {errors.verify}
+          </span>
+          {user ? (
+            <>
+              <Button
+                onClick={() => {
+                  setLoading(true)
+                  authApi.sendEmailVerification().then(() => setSendEmailSuccess(true)).catch(err => {
+                    const message = err instanceof ApiError ? err.message : "Something went wrong"
+                    setErrors({send: message})
+                  }).finally(() => setLoading(false))
+                }}
+                loading={loading}
+              >Resend Email</Button>
+              {sendEmailSuccess && (
+                <p style={{ marginTop: '5px', fontFamily: 'var(--font-sans)', fontSize: '14px', color: 'var(--color-success)' }}>
+                  Email sent successfully. Please check your inbox.
+                </p>
+              )}
+              {errors.send && (
+                <p style={{ marginTop: '5px', fontFamily: 'var(--font-sans)', fontSize: '14px', color: 'var(--color-danger)' }}>
+                  {errors.send}
+                </p>
+              )}
+            </>
+          ) : (
+            <Button onClick={() => router.push('/sign-in')}>Sign In to Resend Email</Button>
+          )}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/frontend/components/ui/Input.tsx
+++ b/frontend/components/ui/Input.tsx
@@ -30,7 +30,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     const inputId = id ?? generatedId
 
     return (
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', width: fullWidth ? '100%' : undefined }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '5px', width: fullWidth ? '100%' : undefined }}>
         {label && (
           <label
             htmlFor={inputId}

--- a/frontend/components/ui/Modal.tsx
+++ b/frontend/components/ui/Modal.tsx
@@ -3,7 +3,7 @@
 import { ReactNode, useEffect } from 'react'
 
 interface ModalProps {
-  title: string
+  title?: string
   onClose: () => void
   children: ReactNode
   width?: number
@@ -41,14 +41,16 @@ export function Modal({ title, onClose, children, width = 440 }: ModalProps) {
         }}
         onClick={(e) => e.stopPropagation()}
       >
-        <h2 style={{
-          fontFamily: 'Georgia, serif',
-          fontSize: '22px',
-          color: 'var(--color-text-primary)',
-          marginBottom: '20px',
-        }}>
-          {title}
-        </h2>
+        {title && (
+          <h2 style={{
+            fontFamily: 'var(--font-serif)',
+            fontSize: '22px',
+            color: 'var(--color-text-primary)',
+            marginBottom: '20px',
+          }}>
+            {title}
+          </h2>
+        )}
         {children}
       </div>
     </div>

--- a/frontend/components/ui/Spinner.tsx
+++ b/frontend/components/ui/Spinner.tsx
@@ -1,0 +1,26 @@
+
+type Size = 'sm' | 'md' | 'lg'
+
+interface SpinnerProps {
+  size?: Size
+}
+
+const sizeStyles: Record<Size, React.CSSProperties> = {
+  sm: { width: '24px', height: '24px', border: '2px solid rgba(255,255,255,0.4)' },
+  md: { width: '48px', height: '48px', border: '3px solid rgba(255,255,255,0.4)' },
+  lg: { width: '64px', height: '64px', border: '4px solid rgba(255,255,255,0.4)' }
+}
+
+export function Spinner({ size = 'md' }: SpinnerProps) {
+  return (
+    <span style={{
+      ...sizeStyles[size],
+      borderTopColor: 'var(--color-text-primary)',
+      borderRadius:   '50%',
+      display:        'inline-block',
+      animation:      'btn-spin 600ms linear infinite',
+    }}>
+      <style>{`@keyframes btn-spin { to { transform: rotate(360deg); } }`}</style>
+    </span>
+  )
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -95,6 +95,7 @@ interface UserBase {
 export interface User extends UserBase {
   id:                  number
   
+  email_verified:      boolean
   role:                ROLE
   is_active:           boolean
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -119,6 +119,8 @@ export const authApi = {
   logout: ()                               => api.post<void>('/auth/logout/', {}),
   me: ()                                   => api.get<User>('/auth/me/'),
   register: (body: AuthRegister)           => api.post<User>('/auth/register/', body),
+  verifyEmail: (token: string)             => api.get<void>(`/auth/verify-email/?token=${token}`),
+  sendEmailVerification: ()                => api.post<void>('/auth/send-email-verification/', {}),
 }
 
 

--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -28,6 +28,15 @@ export function proxy(request: NextRequest) {
     return NextResponse.redirect(url)
   }
 
+  if (pathname === '/verify-email') {
+    const verifyToken = request.nextUrl.searchParams.get('token')
+    if (!verifyToken) {
+      const url = request.nextUrl.clone()
+      url.pathname = token ? '/dashboard' : '/'
+      return NextResponse.redirect(url)
+    }
+  }
+
   return NextResponse.next()
 }
 


### PR DESCRIPTION
## Background

Users can register and log in without verifying their email. Verification is a nudge, not a blocker — unverified users can access the app but see a banner prompting them to verify (banner itself is tracked separately, see Notes).

## Changes

### Backend

- `email_verified` column on `User` (`Boolean, nullable=False, default=False`) with migration — kept separate from `is_active`, which belongs to the admin-activation flow
- `app/core/email_verification.py`:
  - `generate_verification_token(user_id: int) -> str` — signed JWT, 24h `exp`, `aud: "email_verification"` claim
  - `verify_verification_token(token: str) -> int | None` — returns `user_id` if valid, `None` if expired/invalid/wrong audience
- `app/services/email_service.py` — thin async wrapper around Resend (`resend`, using `send_async`); `send_verification_email(to: str, token: str)`; sends from `verify@nexus.ethanshih.com` (deliberately not `noreply@`, to avoid spam-filtering), no `reply_to`
- `GET /auth/verify-email/?token=` — public; validates token, sets `email_verified=True`; idempotent; 400 with a clear message on invalid/expired tokens
- `POST /auth/send-email-verification/` — authenticated; 400 if already verified; `# todo: add rate limiting`
- `RESEND_API_KEY` added to `Settings` (`app/core/config.py`) and `.env`
- `FRONTEND_URL` added/confirmed in `Settings` — used to build the verification link in the email body

**Intentionally disabled for now:** the actual send call in `send-email-verification` is commented out (`_send_verification_email(...)`), and `register()` never calls it either. This is deliberate — Resend's free tier has a sending limit and we don't want every registration burning it during dev/testing. Wiring both call sites back up is a follow-up, not a bug.

### Frontend

- `/verify-email` page — reads `token` from query params on mount, calls `authApi.verifyEmail(token)`; loading → success or error state; success shows a "go to dashboard" button when logged in; error surfaces the backend's message (e.g. "Invalid or expired token")
- `VerifyModal` shown over the sign-up flow's profile-enrichment step, after step 1 registration: "We sent a verification email to {email}. You can verify later — let's finish your profile."
- `authApi.verifyEmail(token)` → `GET /auth/verify-email/?token=`
- `authApi.sendEmailVerification()` → `POST /auth/send-email-verification/`
- `proxy.ts`: visiting `/verify-email` without a `token` param redirects to `/dashboard` (logged in) or `/` (logged out)

## Testing

- Verified token generation/validation, including expired-token and wrong-audience rejection
- Manually walked `/verify-email` success and error states (using a manually-minted token, since sending is currently disabled)
- Manually verified idempotency (visiting the verify link twice doesn't error)
- Confirmed branch builds/runs in isolation, based on top of `feat/signin-and-signup`

## Known gaps / follow-ups

- **No email is actually sent yet, on purpose.** Both call sites (`register()` and `send-email-verification`) are wired for it but the send is disabled to stay under the Resend free-tier limit during dev. Re-enable both before this feature is user-facing.
- `resend` is a plain dependency (`resend==2.32.2`) — no `[async]` extra needed; `send_async` is a normal method on the base package.

## Notes

- Sending domain `verify@nexus.ethanshih.com` is verified in Resend; SPF/DKIM DNS records are set in Vercel DNS; no MX records, since this is send-only
- Token carries an `aud` claim specifically so a login/session JWT can't be reused as a verification token (see security gap above for the unaddressed reverse case)
- The dashboard nudge banner for unverified email is tracked separately in [#45](https://github.com/ethnjs/nexus/issues/45)
- This PR is based on top of `feat/signin-and-signup` — depends on that landing first, or should be rebased onto `main` once it does
- Unrelated changes riding along in this branch, worth a quick look during review: `database_url` default flipped from SQLite to Postgres in `config.py`; `_find_user_by_id` moved from `users.py` to shared `core/users.py`; small `Modal.tsx`/`Input.tsx` tweaks and a new `Spinner.tsx` component