### PR TITLE
feat/contextual nudge banners on dashboard for unverified email and incomplete profile

### DIFF
--- a/frontend/app/(auth)/sign-up/page.tsx
+++ b/frontend/app/(auth)/sign-up/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react"
 import { User, STUDENT_STATUS, authApi, ApiError, SHIRT_SIZE, usersApi } from "@/lib/api"
 import { useRouter } from "next/navigation"
 import { checkPassword, formatPhone, validateEmail, validatePassword, validatePhone } from "@/lib/auth"
-import { IconArrowLeft, IconCheckCircleSolid, IconXCircleSolid } from "@/components/ui/Icons"
+import { IconArrowLeft, IconCheckCircle, IconXCircle } from "@/components/ui/Icons"
 import { Input } from "@/components/ui/Input"
 import { Button } from "@/components/ui/Button"
 import { Select } from "@/components/ui/Select"
@@ -216,7 +216,7 @@ export default function SignUpPage() {
     return (
       <Modal onClose={() => {}}>
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center' }}>
-          <IconCheckCircleSolid style={{ color: 'var(--color-success)', marginBottom: '20px' }} size={72} />
+          <IconCheckCircle style={{ color: 'var(--color-success)', marginBottom: '20px' }} size={72} />
           <h2 style={{ fontFamily: 'var(--font-serif)', fontSize: '22px', color: 'var(--color-text-primary)', marginBottom: '10px' }}>
             Your account was created successfully
           </h2>
@@ -383,8 +383,8 @@ export default function SignUpPage() {
               ].map(({ key, label}) => (
                 <div key={key} style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
                   {passwordChecks[key as keyof typeof passwordChecks]
-                    ? <IconCheckCircleSolid style={{ color: 'var(--color-success)' }} />
-                    : <IconXCircleSolid style={{ color: 'var(--color-danger)' }} />
+                    ? <IconCheckCircle style={{ color: 'var(--color-success)' }} />
+                    : <IconXCircle style={{ color: 'var(--color-danger)' }} />
                   }
                   <span style={{ fontFamily: 'var(--font-sans)', fontSize: '14px'}}>{label}</span>
                 </div>

--- a/frontend/app/(auth)/verify-email/page.tsx
+++ b/frontend/app/(auth)/verify-email/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Button } from "@/components/ui/Button"
-import { IconCheckCircleSolid, IconXCircleSolid } from "@/components/ui/Icons"
+import { IconCheckCircle, IconXCircle } from "@/components/ui/Icons"
 import { Spinner } from "@/components/ui/Spinner"
 import { ApiError, authApi, User } from "@/lib/api"
 import { useRouter, useSearchParams } from "next/navigation"
@@ -84,7 +84,7 @@ function VerifyEmailContent() {
       {state === 2 && (
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
           <span style={{ marginBottom: '10px', display: 'flex', gap: '5px', alignItems: 'center', fontFamily: 'var(--font-sans)', fontSize: '16px', color: 'var(--color-text-primary)' }}>
-              <IconCheckCircleSolid style={{ color: 'var(--color-success)'}} size={16} />Email successfully verified.
+              <IconCheckCircle style={{ color: 'var(--color-success)'}} size={16} />Email successfully verified.
           </span>
           {user ? (
             <Button onClick={() => router.push('/dashboard')}>Go to Dashboard</Button>
@@ -99,7 +99,7 @@ function VerifyEmailContent() {
       {state === 3 && (
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center'}}>
           <span style={{ marginBottom: '10px', alignItems: 'center', display: 'flex', gap: '6px', fontFamily: 'var(--font-sans)', fontSize: '16px', color: 'var(--color-text-primary)' }}>
-              <IconXCircleSolid style={{ color: 'var(--color-danger)'}} size={16} />Error: {errors.verify}
+              <IconXCircle style={{ color: 'var(--color-danger)'}} size={16} />Error: {errors.verify}
           </span>
           {user ? (
             <>

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -9,6 +9,7 @@ import { Banner, BannerProps } from "@/components/ui/Banner"
 import { Button } from "@/components/ui/Button"
 import { IconPlus, IconCalendar, IconLocation } from "@/components/ui/Icons"
 import { useAuth } from "@/lib/useAuth"
+import { Tooltip, TooltipStatus } from "@/components/ui/Tooltip"
 
 
 
@@ -89,6 +90,8 @@ function TournamentCard({ tournament, counts, onClick }: { tournament: Tournamen
 
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
+
+
 export default function DashboardPage() {
   const router = useRouter()
   const [tournaments, setTournaments] = useState<Tournament[]>([])
@@ -106,22 +109,35 @@ export default function DashboardPage() {
     }
   })
 
+  const [tooltipStatus, setTooltipStatus] = useState<Record<string, TooltipStatus>>({"resendEmail": 'idle'})
+  const [errors, setErrors] = useState<Record<string, string>>({})
+
   const user = useAuth().user
+
+  const resendEmailTooltipMessages: Partial<Record<TooltipStatus, string | undefined>> = {
+    'success': "Email sent successfully. Please check your inbox.",
+    'error': errors["resendEmail"] ?? undefined
+  }
 
   const bannerRules: BannerRule[] = [
     {id: 1, variant: "warning", message: "Please verify your email address", 
       condition: user => !user.email_verified, snoozeDays: 1,
-      action: <Button
-        variant="secondary"
-        onClick={() => {
-          setLoading(l => ({...l, "verify-email": true}))
-          authApi.sendEmailVerification().then(/* () => setSendEmailSuccess(true) */ () => {}).catch(err => {
-            const message = err instanceof ApiError ? err.message : "Something went wrong"
-            // setErrors({send: message})
-          }).finally(() => setLoading(l => ({...l, "verify-email": false})))
-        }}
-        loading={loading["verify-email"]}
-      >Resend Email</Button>
+      action: <Tooltip
+        status={tooltipStatus["resendEmail"]}
+        message={resendEmailTooltipMessages}
+      ><Button
+          variant="secondary"
+          onClick={() => {
+            setLoading(l => ({...l, "verify-email": true}))
+            authApi.sendEmailVerification().then(() => setTooltipStatus(s => ({...s, "resendEmail": 'success'}))).catch(err => {
+              const message = err instanceof ApiError ? err.message : "Something went wrong"
+              setTooltipStatus(s => ({...s, "resendEmail": 'error'}))
+              setErrors({"resendEmail": message})
+            }).finally(() => setLoading(l => ({...l, "verify-email": false})))
+          }}
+          loading={loading["verify-email"]}
+        >Resend Email</Button>
+      </Tooltip>
     },
     {id: 2, variant: "warning", message: "Your profile is incomplete",
       condition: user => user.missing_profile_fields.length > 0, snoozeDays: 3,
@@ -136,6 +152,8 @@ export default function DashboardPage() {
     if (!user) return false
     return e.condition(user) && (new Date(Date.now()).toISOString() >= (dismissedBanners[e.id] ?? ''))
   })
+
+  
 
   useEffect(() => {
     tournamentsApi.list().then((data) => {

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -127,6 +127,7 @@ export default function DashboardPage() {
         message={resendEmailTooltipMessages}
       ><Button
           variant="secondary"
+          size="sm"
           onClick={() => {
             setLoading(l => ({...l, "verify-email": true}))
             authApi.sendEmailVerification().then(() => setTooltipStatus(s => ({...s, "resendEmail": 'success'}))).catch(err => {
@@ -143,6 +144,7 @@ export default function DashboardPage() {
       condition: user => user.missing_profile_fields.length > 0, snoozeDays: 3,
       action: <Button
         variant="secondary"
+        size="sm"
         onClick={() => router.push('/dashboard')} // temp for now, will push to profile later
       >Complete Profile</Button>
     }

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,28 +1,39 @@
-"use client";
+"use client"
 
-import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
-import { tournamentsApi, eventsApi, membershipsApi, Tournament } from "@/lib/api";
-import { NewTournamentModal } from "@/components/ui/NewTournamentModal";
-import { Topbar } from "@/components/layout/Topbar";
-import { Button } from "@/components/ui/Button";
-import { IconPlus, IconCalendar, IconLocation } from "@/components/ui/Icons";
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import { tournamentsApi, eventsApi, membershipsApi, Tournament, User, authApi, ApiError } from "@/lib/api"
+import { NewTournamentModal } from "@/components/ui/NewTournamentModal"
+import { Topbar } from "@/components/layout/Topbar"
+import { Banner, BannerProps } from "@/components/ui/Banner"
+import { Button } from "@/components/ui/Button"
+import { IconPlus, IconCalendar, IconLocation } from "@/components/ui/Icons"
+import { useAuth } from "@/lib/useAuth"
+
+
+
+interface BannerRule extends Omit<BannerProps, 'onDismiss'> {
+  id: number
+  condition: (user: User) => boolean
+  snoozeDays: number
+}
+
 
 // ─── Tournament Card ──────────────────────────────────────────────────────────
 
-interface CardCounts { events: number | null; volunteers: number | null; }
+interface CardCounts { events: number | null; volunteers: number | null }
 
 function TournamentCard({ tournament, counts, onClick }: { tournament: Tournament; counts: CardCounts; onClick: () => void }) {
-  const [hovered, setHovered] = useState(false);
+  const [hovered, setHovered] = useState(false)
 
   const fmt = (d: string) =>
-    new Date(d).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    new Date(d).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })
 
   const dateRange = tournament.start_date
     ? tournament.end_date && tournament.end_date !== tournament.start_date
       ? `${fmt(tournament.start_date)} – ${fmt(tournament.end_date)}`
       : fmt(tournament.start_date)
-    : null;
+    : null
 
   return (
     <button
@@ -73,38 +84,84 @@ function TournamentCard({ tournament, counts, onClick }: { tournament: Tournamen
         </div>
       </div>
     </button>
-  );
+  )
 }
 
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default function DashboardPage() {
-  const router = useRouter();
-  const [tournaments, setTournaments] = useState<Tournament[]>([]);
-  const [counts, setCounts]           = useState<Record<number, CardCounts>>({});
-  const [loading, setLoading]         = useState(true);
-  const [showModal, setShowModal]     = useState(false);
+  const router = useRouter()
+  const [tournaments, setTournaments] = useState<Tournament[]>([])
+  const [counts, setCounts]           = useState<Record<number, CardCounts>>({})
+  const [loading, setLoading]         = useState<Record<string, boolean>>({"page": true})
+  const [showModal, setShowModal]     = useState(false)
+
+  const [dismissedBanners, setDismissedBanners] = useState<Record<number, string>>(() => {
+    const dismissed = localStorage.getItem('dismissedBanners')
+    if (!dismissed) return {}
+    try {
+      return JSON.parse(dismissed)
+    } catch {
+      return {}
+    }
+  })
+
+  const user = useAuth().user
+
+  const bannerRules: BannerRule[] = [
+    {id: 1, variant: "warning", message: "Please verify your email address", 
+      condition: user => !user.email_verified, snoozeDays: 1,
+      action: <Button
+        variant="secondary"
+        onClick={() => {
+          setLoading(l => ({...l, "verify-email": true}))
+          authApi.sendEmailVerification().then(() => setSendEmailSuccess(true)).catch(err => {
+            const message = err instanceof ApiError ? err.message : "Something went wrong"
+            setErrors({send: message})
+          }).finally(() => setLoading(l => ({...l, "verify-email": false})))
+        }}
+        loading={loading["verify-email"]}
+      >Resend Email</Button>
+    },
+    {id: 2, variant: "warning", message: "Your profile is incomplete",
+      condition: user => user.missing_profile_fields.length > 0, snoozeDays: 3,
+      action: <Button
+        variant="secondary"
+        onClick={() => router.push('/dashboard')} // temp for now, will push to profile later
+      >Complete Profile</Button>
+    }
+  ]
+
+  const activeBanners = bannerRules.filter(e => {
+    if (!user) return false
+    return e.condition(user) && (new Date(Date.now()).toISOString() >= (dismissedBanners[e.id] ?? ''))
+  })
 
   useEffect(() => {
     tournamentsApi.list().then((data) => {
-      setTournaments(data);
-      setLoading(false);
+      setTournaments(data)
       data.forEach((t) => {
         Promise.all([
           eventsApi.listByTournament(t.id).then((e) => e.length).catch(() => 0),
           membershipsApi.listByTournament(t.id).then((m) => m.length).catch(() => 0),
         ]).then(([events, volunteers]) => {
-          setCounts((prev) => ({ ...prev, [t.id]: { events, volunteers } }));
-        });
-      });
-    }).catch(() => setLoading(false));
-  }, []);
+          setCounts((prev) => ({ ...prev, [t.id]: { events, volunteers } }))
+        })
+      })
+    }).catch(() => {}).finally(() => setLoading(l => ({...l, "page": false})))
+  }, [])
 
   function handleCreated(t: Tournament) {
-    setTournaments((prev) => [...prev, t]);
-    setCounts((prev) => ({ ...prev, [t.id]: { events: 0, volunteers: 0 } }));
-    setShowModal(false);
-    router.push(`/dashboard/${t.id}/overview`);
+    setTournaments((prev) => [...prev, t])
+    setCounts((prev) => ({ ...prev, [t.id]: { events: 0, volunteers: 0 } }))
+    setShowModal(false)
+    router.push(`/dashboard/${t.id}/overview`)
+  }
+
+  function dismissBanner(id: number, snoozeDays: number) {
+    const dismissed = {...dismissedBanners, [id]: new Date(Date.now() + snoozeDays * 24 * 60 * 60 * 1000).toISOString()}
+    setDismissedBanners(dismissed)
+    localStorage.setItem('dismissedBanners', JSON.stringify(dismissed))
   }
 
   return (
@@ -113,11 +170,25 @@ export default function DashboardPage() {
 
       <main style={{ flex: 1, overflowY: "auto", padding: "28px" }}>
         <div style={{ maxWidth: "960px", margin: "0 auto" }}>
+          
+          {activeBanners.length > 0 && activeBanners.map(({ id, variant, message, action, snoozeDays }) => {
+            return (
+              <div key={id} style={{ marginBottom: '15px' }}>
+                <Banner
+                  variant={variant}
+                  message={message}
+                  action={action}
+                  onDismiss={() => dismissBanner(id, snoozeDays)}
+                />
+              </div>
+            )
+          })}
+
           <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "24px" }}>
             <div>
               <h1 style={{ fontSize: "28px", marginBottom: "4px" }}>Tournaments</h1>
               <p style={{ fontFamily: "var(--font-sans)", fontSize: "14px", color: "var(--color-text-secondary)" }}>
-                {loading ? "" : tournaments.length === 0 ? "No tournaments yet" : `${tournaments.length} tournament${tournaments.length !== 1 ? "s" : ""}`}
+                {loading["page"] ? "" : tournaments.length === 0 ? "No tournaments yet" : `${tournaments.length} tournament${tournaments.length !== 1 ? "s" : ""}`}
               </p>
             </div>
             <Button variant="primary" size="md" onClick={() => setShowModal(true)}>
@@ -126,7 +197,7 @@ export default function DashboardPage() {
             </Button>
           </div>
 
-          {loading ? (
+          {loading["page"] ? (
             <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))", gap: "16px" }}>
               {[1, 2, 3].map((i) => (
                 <div key={i} style={{ height: "180px", background: "var(--color-surface)", border: "1px solid var(--color-border)", borderRadius: "var(--radius-lg)", opacity: 0.5 }} />
@@ -159,5 +230,5 @@ export default function DashboardPage() {
         <NewTournamentModal onClose={() => setShowModal(false)} onCreated={handleCreated} />
       )}
     </div>
-  );
+  )
 }

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -97,7 +97,7 @@ export default function DashboardPage() {
   const [showModal, setShowModal]     = useState(false)
 
   const [dismissedBanners, setDismissedBanners] = useState<Record<number, string>>(() => {
-    const dismissed = localStorage.getItem('dismissedBanners')
+    const dismissed = typeof window !== "undefined" ? localStorage.getItem("dismissedBanners") : "{}"
     if (!dismissed) return {}
     try {
       return JSON.parse(dismissed)
@@ -115,9 +115,9 @@ export default function DashboardPage() {
         variant="secondary"
         onClick={() => {
           setLoading(l => ({...l, "verify-email": true}))
-          authApi.sendEmailVerification().then(() => setSendEmailSuccess(true)).catch(err => {
+          authApi.sendEmailVerification().then(/* () => setSendEmailSuccess(true) */ () => {}).catch(err => {
             const message = err instanceof ApiError ? err.message : "Something went wrong"
-            setErrors({send: message})
+            // setErrors({send: message})
           }).finally(() => setLoading(l => ({...l, "verify-email": false})))
         }}
         loading={loading["verify-email"]}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -106,14 +106,17 @@
   --color-accent-hover:  #2A2A2A;
   --color-accent-subtle: #F0F0EC;
 
-  --color-danger:         #E53E3E;
-  --color-danger-subtle:  #FFF5F5;
+  --color-danger:              #E53E3E;
+  --color-danger-subtle:       #FFF5F5;
+  --color-danger-subtle-hover: #FEEAEA;
+  
+  --color-success:              #22C55E;
+  --color-success-subtle:       #F0FDF4;
+  --color-success-subtle-hover: #E6FAF0;
 
-  --color-success:        #22C55E;
-  --color-success-subtle: #F0FDF4;
-
-  --color-warning:        #EAB308;
-  --color-warning-subtle: #FEFCE8;
+  --color-warning:              #EAB308;
+  --color-warning-subtle:       #FEFCE8;
+  --color-warning-subtle-hover: #FDF8D0;
 
   /* Status badge colors — muted, desaturated */
   --color-status-interested: #6B6B65;

--- a/frontend/components/ui/Banner.tsx
+++ b/frontend/components/ui/Banner.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { ReactNode } from 'react'
-import { IconXCircle, IconWarning, IconCheckCircle, IconInfo } from '@/components/ui/Icons'
+import { IconXCircle, IconWarning, IconCheckCircle, IconInfo, IconX } from '@/components/ui/Icons'
 
 type BannerVariant = 'success' | 'error' | 'warning' | 'info'
 
@@ -15,31 +15,35 @@ export interface BannerProps {
 }
 
 const variantTokens: Record<BannerVariant, {
-  bg: string; border: string; iconColor: string; icon: ReactNode
+  bg: string; border: string; iconColor: string; icon: ReactNode; dismissHoverBg: string
 }> = {
   success: {
-    bg:        'var(--color-surface)',
-    border:    'var(--color-success)',
-    iconColor: 'var(--color-success)',
-    icon:      <IconCheckCircle size={20} />,
+    bg:             'var(--color-surface)',
+    border:         'var(--color-success)',
+    iconColor:      'var(--color-success)',
+    icon:           <IconCheckCircle size={20} />,
+    dismissHoverBg: 'rgba(34,197,94,0.12)',
   },
   error: {
-    bg:        'var(--color-danger-subtle)',
-    border:    'var(--color-danger)',
-    iconColor: 'var(--color-danger)',
-    icon:      <IconXCircle size={20} />,
+    bg:             'var(--color-danger-subtle)',
+    border:         'var(--color-danger)',
+    iconColor:      'var(--color-danger)',
+    icon:           <IconXCircle size={20} />,
+    dismissHoverBg: 'rgba(229,62,62,0.12)',
   },
   warning: {
-    bg:        'var(--color-warning-subtle)',
-    border:    'var(--color-warning)',
-    iconColor: 'var(--color-warning)',
-    icon:      <IconWarning size={20} />,
+    bg:             'var(--color-warning-subtle)',
+    border:         'var(--color-warning)',
+    iconColor:      'var(--color-warning)',
+    icon:           <IconWarning size={20} />,
+    dismissHoverBg: 'rgba(234,179,8,0.12)',
   },
   info: {
-    bg:        'var(--color-surface)',
-    border:    'var(--color-border-strong)',
-    iconColor: 'var(--color-text-secondary)',
-    icon:      <IconInfo size={20} />,
+    bg:             'var(--color-surface)',
+    border:         'var(--color-border-strong)',
+    iconColor:      'var(--color-text-secondary)',
+    icon:           <IconInfo size={20} />,
+    dismissHoverBg: 'rgba(0,0,0,0.06)',
   },
 }
 
@@ -84,20 +88,29 @@ export function Banner({ variant, message, action, onDismiss }: BannerProps) {
         <button
           onClick={onDismiss}
           style={{
-            background:  'none',
-            border:      'none',
-            cursor:      'pointer',
-            fontFamily:  'var(--font-sans)',
-            fontSize:    '12px',
-            color:       'var(--color-text-tertiary)',
-            padding:     '0 2px',
-            lineHeight:  1,
-            flexShrink:  0,
+            background:   'none',
+            border:       'none',
+            cursor:       'pointer',
+            color:        'var(--color-text-tertiary)',
+            width:        '28px',
+            height:       '28px',
+            padding:      '0',
+            borderRadius: 'var(--radius-sm)',
+            flexShrink:   0,
+            display:      'flex',
+            alignItems:   'center',
+            justifyContent: 'center',
           }}
-          onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--color-text-primary)'; }}
-          onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--color-text-tertiary)'; }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.color = 'var(--color-text-primary)';
+            e.currentTarget.style.background = t.dismissHoverBg;
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.color = 'var(--color-text-tertiary)';
+            e.currentTarget.style.background = 'none';
+          }}
         >
-          ✕
+          <IconX />
         </button>
       )}
     </div>

--- a/frontend/components/ui/Banner.tsx
+++ b/frontend/components/ui/Banner.tsx
@@ -5,7 +5,7 @@ import { IconErrorCircle, IconWarningBanner, IconCheckCircle } from '@/component
 
 type BannerVariant = 'success' | 'error' | 'warning' | 'info'
 
-interface BannerProps {
+export interface BannerProps {
   variant: BannerVariant
   message: string
   /** Optional ReactNode rendered to the right of the message — e.g. a Button */

--- a/frontend/components/ui/Banner.tsx
+++ b/frontend/components/ui/Banner.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { ReactNode } from 'react'
-import { IconErrorCircle, IconWarningBanner, IconCheckCircle } from '@/components/ui/Icons'
+import { IconXCircle, IconWarning, IconCheckCircle, IconInfo } from '@/components/ui/Icons'
 
 type BannerVariant = 'success' | 'error' | 'warning' | 'info'
 
@@ -21,26 +21,25 @@ const variantTokens: Record<BannerVariant, {
     bg:        'var(--color-surface)',
     border:    'var(--color-success)',
     iconColor: 'var(--color-success)',
-    icon:      <IconCheckCircle size={15} />,
+    icon:      <IconCheckCircle size={20} />,
   },
   error: {
     bg:        'var(--color-danger-subtle)',
     border:    'var(--color-danger)',
     iconColor: 'var(--color-danger)',
-    icon:      <IconErrorCircle size={15} />,
+    icon:      <IconXCircle size={20} />,
   },
   warning: {
     bg:        'var(--color-warning-subtle)',
     border:    'var(--color-warning)',
     iconColor: 'var(--color-warning)',
-    icon:      <IconWarningBanner size={17} />,
+    icon:      <IconWarning size={20} />,
   },
   info: {
     bg:        'var(--color-surface)',
     border:    'var(--color-border-strong)',
     iconColor: 'var(--color-text-secondary)',
-    // info keeps a simple character since it's rarely used
-    icon:      <span style={{ fontSize: '13px', fontWeight: 700, lineHeight: 1 }}>ℹ</span>,
+    icon:      <IconInfo size={20} />,
   },
 }
 
@@ -66,7 +65,7 @@ export function Banner({ variant, message, action, onDismiss }: BannerProps) {
       {/* Message */}
       <span style={{
         fontFamily: 'var(--font-sans)',
-        fontSize:   '13px',
+        fontSize:   '14px',
         color:      'var(--color-text-primary)',
         flex:       1,
       }}>

--- a/frontend/components/ui/Button.tsx
+++ b/frontend/components/ui/Button.tsx
@@ -68,8 +68,8 @@ const variantHoverBorderColor: Record<Variant, string | null> = {
 }
 
 const sizeStyles: Record<Size, React.CSSProperties> = {
-  sm: { height: '36px', padding: '0 14px', fontSize: '13px', gap: '7px' },
-  md: { height: '38px', padding: '0 16px', fontSize: '14px', gap: '8px' },
+  sm: { height: '28px', padding: '0 14px', fontSize: '12px', gap: '6px' },
+  md: { height: '36px', padding: '0 16px', fontSize: '14px', gap: '8px' },
   lg: { height: '48px', padding: '0 20px', fontSize: '15px', gap: '8px' },
 }
 

--- a/frontend/components/ui/Icons.tsx
+++ b/frontend/components/ui/Icons.tsx
@@ -198,59 +198,24 @@ export function IconArrowDown({ size = 22, ...props }: IconProps) {
 
 export function IconCheckCircle({ size = 16, ...props }: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" style={props.style} className={props.className}>
-      <circle cx="8" cy="8" r="7" stroke="currentColor" strokeWidth="1.5" />
-      <path d="M5 8l2 2 4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    <svg width={size} height={size} viewBox="0 0 640 640" fill="currentColor" style={{ flexShrink: 0, ...props.style }} className={props.className}>
+      <path d="M320 576C178.6 576 64 461.4 64 320C64 178.6 178.6 64 320 64C461.4 64 576 178.6 576 320C576 461.4 461.4 576 320 576zM438 209.7C427.3 201.9 412.3 204.3 404.5 215L285.1 379.2L233 327.1C223.6 317.7 208.4 317.7 199.1 327.1C189.8 336.5 189.7 351.7 199.1 361L271.1 433C276.1 438 282.9 440.5 289.9 440C296.9 439.5 303.3 435.9 307.4 430.2L443.3 243.2C451.1 232.5 448.7 217.5 438 209.7z" />
     </svg>
   );
 }
 
-/**
- * Circle with an X inside — X has breathing room from the circle edge.
- * Used for error states in banners and feedback UI.
- */
-export function IconErrorCircle({ size = 16, ...props }: IconProps) {
+export function IconXCircle({ size = 16, ...props }: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" style={props.style} className={props.className}>
-      {/* Outer circle — slightly thinner so it doesn't visually merge with the X */}
-      <circle cx="8" cy="8" r="6.5" stroke="currentColor" strokeWidth="1.4" />
-      {/* X — inset from the circle so there's clear space between them */}
-      <path d="M5.5 5.5l5 5M10.5 5.5l-5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-    </svg>
-  );
-}
-
-/**
- * Warning triangle — slightly larger exclamation mark for better legibility.
- * Used for warning states in banners and feedback UI.
- */
-export function IconWarningBanner({ size = 18, ...props }: IconProps) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 18 18" fill="none" style={props.style} className={props.className}>
-      <path
-        d="M8.13 2.4a1.05 1.05 0 0 1 1.74 0l6.3 10.5A1.05 1.05 0 0 1 15.3 14.5H2.7a1.05 1.05 0 0 1-.87-1.6L8.13 2.4z"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinejoin="round"
-      />
-      {/* Taller stem for better legibility */}
-      <path d="M9 7v3.5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
-      <circle cx="9" cy="12.25" r="0.85" fill="currentColor" />
+    <svg width={size} height={size} viewBox="0 0 640 640" fill="currentColor" style={{ flexShrink: 0, ...props.style }} className={props.className}>
+      <path d="M320 576C178.6 576 64 461.4 64 320C64 178.6 178.6 64 320 64C461.4 64 576 178.6 576 320C576 461.4 461.4 576 320 576zM435.3 204.7C424.6 194 407.4 194 396.7 204.7L320 281.4L243.3 204.7C232.6 194 215.4 194 204.7 204.7C194 215.4 194 232.6 204.7 243.3L281.4 320L204.7 396.7C194 407.4 194 424.6 204.7 435.3C215.4 446 232.6 446 243.3 435.3L320 358.6L396.7 435.3C407.4 446 424.6 446 435.3 435.3C446 424.6 446 407.4 435.3 396.7L358.6 320L435.3 243.3C446 232.6 446 215.4 435.3 204.7z" />
     </svg>
   );
 }
 
 export function IconWarning({ size = 16, ...props }: IconProps) {
   return (
-    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" style={props.style} className={props.className}>
-      <path
-        d="M7.08 2.48a1.05 1.05 0 0 1 1.84 0l5.6 9.8A1.05 1.05 0 0 1 13.6 14H2.4a1.05 1.05 0 0 1-.92-1.72l5.6-9.8z"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinejoin="round"
-      />
-      <path d="M8 6.5v3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-      <circle cx="8" cy="11.5" r="0.75" fill="currentColor" />
+    <svg width={size} height={size} viewBox="0 0 640 640" fill="currentColor" style={{ flexShrink: 0, ...props.style }} className={props.className}>
+      <path d="M320 64C334.7 64 348.2 72.1 355.2 85L571.2 485C577.9 497.4 577.6 512.4 570.4 524.5C563.2 536.6 550.1 544 536 544L104 544C89.9 544 76.8 536.6 69.6 524.5C62.4 512.4 62.1 497.4 68.8 485L284.8 85C291.8 72.1 305.3 64 320 64zM320 416C302.3 416 288 430.3 288 448C288 465.7 302.3 480 320 480C337.7 480 352 465.7 352 448C352 430.3 337.7 416 320 416zM320 224C301.8 224 287.3 239.5 288.6 257.7L296 361.7C296.9 374.2 307.4 384 319.9 384C332.5 384 342.9 374.3 343.8 361.7L351.2 257.7C352.5 239.5 338.1 224 319.8 224z" />
     </svg>
   );
 }
@@ -275,18 +240,10 @@ export function IconLocation({ size = 13, ...props }: IconProps) {
   );
 }
 
-export function IconCheckCircleSolid({ size = 16, ...props }: IconProps) {
+export function IconInfo({ size = 16, ...props }: IconProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 640 640" fill="currentColor" style={{ flexShrink: 0, ...props.style }} className={props.className}>
-      <path d="M320 576C178.6 576 64 461.4 64 320C64 178.6 178.6 64 320 64C461.4 64 576 178.6 576 320C576 461.4 461.4 576 320 576zM438 209.7C427.3 201.9 412.3 204.3 404.5 215L285.1 379.2L233 327.1C223.6 317.7 208.4 317.7 199.1 327.1C189.8 336.5 189.7 351.7 199.1 361L271.1 433C276.1 438 282.9 440.5 289.9 440C296.9 439.5 303.3 435.9 307.4 430.2L443.3 243.2C451.1 232.5 448.7 217.5 438 209.7z" />
-    </svg>
-  );
-}
-
-export function IconXCircleSolid({ size = 16, ...props }: IconProps) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 640 640" fill="currentColor" style={{ flexShrink: 0, ...props.style }} className={props.className}>
-      <path d="M320 576C178.6 576 64 461.4 64 320C64 178.6 178.6 64 320 64C461.4 64 576 178.6 576 320C576 461.4 461.4 576 320 576zM435.3 204.7C424.6 194 407.4 194 396.7 204.7L320 281.4L243.3 204.7C232.6 194 215.4 194 204.7 204.7C194 215.4 194 232.6 204.7 243.3L281.4 320L204.7 396.7C194 407.4 194 424.6 204.7 435.3C215.4 446 232.6 446 243.3 435.3L320 358.6L396.7 435.3C407.4 446 424.6 446 435.3 435.3C446 424.6 446 407.4 435.3 396.7L358.6 320L435.3 243.3C446 232.6 446 215.4 435.3 204.7z" />
+      <path d="M320 576C461.4 576 576 461.4 576 320C576 178.6 461.4 64 320 64C178.6 64 64 178.6 64 320C64 461.4 178.6 576 320 576zM288 224C288 206.3 302.3 192 320 192C337.7 192 352 206.3 352 224C352 241.7 337.7 256 320 256C302.3 256 288 241.7 288 224zM280 288L328 288C341.3 288 352 298.7 352 312L352 400L360 400C373.3 400 384 410.7 384 424C384 437.3 373.3 448 360 448L280 448C266.7 448 256 437.3 256 424C256 410.7 266.7 400 280 400L304 400L304 336L280 336C266.7 336 256 325.3 256 312C256 298.7 266.7 288 280 288z" />
     </svg>
   );
 }

--- a/frontend/components/ui/Icons.tsx
+++ b/frontend/components/ui/Icons.tsx
@@ -240,6 +240,14 @@ export function IconLocation({ size = 13, ...props }: IconProps) {
   );
 }
 
+export function IconX({ size = 12, ...props }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 640 640" fill="currentColor" style={{ flexShrink: 0, ...props.style }} className={props.className}>
+      <path d="M504.6 148.5C515.9 134.9 514.1 114.7 500.5 103.4C486.9 92.1 466.7 93.9 455.4 107.5L320 270L184.6 107.5C173.3 93.9 153.1 92.1 139.5 103.4C125.9 114.7 124.1 134.9 135.4 148.5L278.3 320L135.4 491.5C124.1 505.1 125.9 525.3 139.5 536.6C153.1 547.9 173.3 546.1 184.6 532.5L320 370L455.4 532.5C466.7 546.1 486.9 547.9 500.5 536.6C514.1 525.3 515.9 505.1 504.6 491.5L361.7 320L504.6 148.5z" />
+    </svg>
+  );
+}
+
 export function IconInfo({ size = 16, ...props }: IconProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 640 640" fill="currentColor" style={{ flexShrink: 0, ...props.style }} className={props.className}>

--- a/frontend/components/ui/Tooltip.module.css
+++ b/frontend/components/ui/Tooltip.module.css
@@ -1,0 +1,67 @@
+.wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
+.wrapper::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  height: 10px;
+}
+
+.bubble {
+  position: absolute;
+  top: calc(100% + 10px);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 50;
+  white-space: nowrap;
+  padding: 7px 11px;
+  border-radius: var(--radius-md);
+  border: none;
+  filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.1)) drop-shadow(0 -2px 6px rgba(0, 0, 0, 0.1));
+  font-family: var(--font-sans);
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* Triangle pointing up */
+.bubble::after {
+  content: '';
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+}
+
+/* ── Variants ──────────────────────────────────────────────── */
+
+.info {
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+}
+.info::after { border-bottom-color: var(--color-surface); }
+
+.success {
+  background: var(--color-success-subtle);
+  color: var(--color-text-primary);
+}
+.success::after { border-bottom-color: var(--color-success-subtle); }
+
+.warning {
+  background: var(--color-warning-subtle);
+  color: var(--color-text-primary);
+}
+.warning::after { border-bottom-color: var(--color-warning-subtle); }
+
+.error {
+  background: var(--color-danger-subtle);
+  color: var(--color-text-primary);
+}
+.error::after { border-bottom-color: var(--color-danger-subtle); }

--- a/frontend/components/ui/Tooltip.tsx
+++ b/frontend/components/ui/Tooltip.tsx
@@ -1,0 +1,60 @@
+import { ReactNode, useEffect, useState } from "react"
+import styles from './Tooltip.module.css'
+import { IconCheckCircle, IconInfo, IconWarning, IconXCircle } from "./Icons"
+
+
+
+type TooltipVariant = 'info' | 'success' | 'warning' | 'error'
+
+export type TooltipStatus = 'idle' | 'success' | 'warning' | 'error'
+
+type TooltipProps = {
+  variant: TooltipVariant
+  status?: never
+  message: string
+  children: ReactNode
+  showIcon?: boolean
+} | {
+  variant?: never
+  status: TooltipStatus
+  message: Partial<Record<TooltipStatus, string | undefined>>
+  children: ReactNode
+  showIcon?: boolean
+}
+
+const variantIcon: Record<TooltipVariant, ReactNode> = {
+  'info': <IconInfo />,
+  'success': <IconCheckCircle style={{color: 'var(--color-success)'}}/>,
+  'warning': <IconWarning style={{color: 'var(--color-warning)'}}/>,
+  'error': <IconXCircle style={{color: 'var(--color-danger)'}}/>
+}
+
+export function Tooltip({ variant, status, message, children, showIcon = true }: TooltipProps) {
+  const [hovered, setHovered] = useState(false)
+  const [autoShow, setAutoShow] = useState(false)
+
+  const visible = (autoShow || (hovered && !!variant) || (hovered && !!status)) && (typeof message === 'string' ? !!message : !!message[status!])
+
+  useEffect(() => {
+    if (variant) return
+    setAutoShow(true)
+    const timerId = setTimeout(() => {
+      setAutoShow(false)
+    }, 3000)
+    return () => clearTimeout(timerId)
+  }, [status])
+
+  const resolvedVariant = variant ?? (status !== 'idle' ? status : 'info')
+
+  return (
+    <div className={styles.wrapper} onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}>
+      {children}
+      {visible && (
+        <div className={`${styles.bubble} ${styles[resolvedVariant]}`}>
+          {showIcon && variantIcon[resolvedVariant]}
+          {typeof message === 'string' ? message : message[status!]}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Background

Users who skip email verification or leave their profile incomplete should be nudged to complete these actions. Banners are informational only — they do not block access to the app.

## Changes

### Unverified email banner

- Shown when `user.email_verified === false`
- Message: "Please verify your email address" + "Resend Email" button
- Resend button calls `authApi.sendEmailVerification()`, with inline success/error feedback via the new Tooltip component
- Banner clears once `user` is refetched with `email_verified: true` (e.g. next page load/reload) — no live refetch or optimistic update on click, and that's fine for now

### Incomplete profile banner

- Shown when `user.missing_profile_fields.length > 0`
- Message: "Your profile is incomplete" + "Complete Profile" button
- Button currently pushes to `/dashboard` as a placeholder (no profile-edit page exists yet — that lands in a follow-up PR)
- Banner clears the same way as the email banner (next fetch of `user` sees an empty list)
- Manual dismiss already implemented: dismissing snoozes the banner via `localStorage` (1 day for email-verify, 3 days for profile), independent per banner

### Supporting UI

- Tooltip component (info + status modes) used by the banners
- Solid default check/x icons, new info icon
- `typeof window` guard around localStorage access, fixing an SSR crash (banner dismiss-state initializer was reading `localStorage` during render)
- Subtle hover background on the banner dismiss button

## Testing

- Manually verified email banner condition and resend button feedback (success/error)
- Manually verified profile banner lists condition correctly and clears once `missing_profile_fields` is empty (via reload)
- Verified both banners can render simultaneously without overlapping, stacked correctly
- Verified snooze/dismiss persists across reload via localStorage, independently per banner
- Confirmed no SSR crash on initial dashboard load (localStorage guard)
- Confirmed branch builds/runs in isolation, based on top of the email verification PR

## Notes

- `missing_profile_fields` is a `@computed_field` on the `UserResponse` schema — never stored, always computed fresh, so the banner reflects current state on every fetch
- Both banners are independent and can be visible at the same time
- Neither banner reactively updates on the action that would clear it (verifying email, completing profile) — both require a fresh fetch of `user`, i.e. navigating away and back or a reload. Current behavior is fine, no changes needed.
- Profile banner's "Complete Profile" button is a placeholder for now; the real `/user/[id]/edit` (or similar) destination is coming in the next PR
- Depends on `email_verified` and `missing_profile_fields` being present on the user object from the auth/email-verification PRs — branched on top of `feat/user-email-verification`