### PR TITLE
feat/structured experience tables

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -10,6 +10,21 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: nexus
+          POSTGRES_PASSWORD: nexus
+          POSTGRES_DB: nexus_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     defaults:
       run:
         working-directory: backend
@@ -32,5 +47,5 @@ jobs:
           APP_ENV: test
           API_KEY: ""
           JWT_SECRET: test-secret
-          DATABASE_URL: ""   # your conftest uses SQLite in-memory, so this can be blank
+          TEST_DATABASE_URL: postgresql://nexus:nexus@127.0.0.1:5432/nexus_test
         run: pytest

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Tournament directors use NEXUS to:
 | Layer | Technology |
 |---|---|
 | Backend | Python 3.13, FastAPI, SQLAlchemy, Alembic |
-| Database | SQLite (dev), PostgreSQL (prod) |
+| Database | PostgreSQL (dev via Docker, prod via Neon) |
 | Frontend | Next.js 15, React, TypeScript, TailwindCSS |
 | Auth | JWT (httpOnly cookie) + API key |
 | Integrations | Google Sheets API (service account) |
-| Hosting | Railway (backend), Vercel (frontend) |
+| Hosting | Render (backend), Vercel (frontend) |
 
 ---
 
@@ -37,7 +37,7 @@ Tournament directors use NEXUS to:
 nexus/
 ├── backend/        # FastAPI app
 │   ├── app/
-│   │   ├── api/routes/     # Auth, tournaments, events, memberships, sheets
+│   │   ├── api/routes/     # Auth, users, tournaments, events, event categories, sheets
 │   │   ├── core/           # Config, auth, permissions
 │   │   ├── db/             # Session, migrations
 │   │   ├── models/         # SQLAlchemy ORM models
@@ -57,19 +57,20 @@ nexus/
 
 ### Backend
 
-**Requirements:** Python 3.13, a Google service account credentials file
+**Requirements:** Python 3.13, Docker, a Google service account credentials file
 
 ```bash
 cd backend
 python -m venv .venv
 .venv\Scripts\activate
 pip install -r requirements.txt
+docker-compose up -d
 ```
 
 Create a `.env` file:
 ```
 APP_ENV=development
-DATABASE_URL=sqlite:///./nexus.db
+DATABASE_URL=postgresql://nexus:nexus@127.0.0.1:5432/nexus
 GOOGLE_SERVICE_ACCOUNT_FILE=./credentials.json
 API_KEY=
 JWT_SECRET=dev-secret-change-in-production
@@ -77,6 +78,7 @@ JWT_SECRET=dev-secret-change-in-production
 
 Run the server:
 ```bash
+alembic upgrade head
 uvicorn app.main:app --reload --port 8001
 ```
 
@@ -109,12 +111,19 @@ pnpm dev
 
 ## Running Tests
 
+Tests run against a dedicated `nexus_test` Postgres database on the same Docker container as dev — this keeps test transaction/rollback semantics identical to prod (SQLite doesn't support the savepoints the test fixtures rely on). Create it once:
+
+```bash
+docker exec backend-db-1 createdb -U nexus nexus_test
+```
+
+Then run:
 ```bash
 cd backend
 pytest
 ```
 
-Tests use an in-memory SQLite database and mock out the Google Sheets API — no external services required.
+Each test runs inside a transaction that's rolled back at teardown, so the test DB never accumulates data. Override the target with `TEST_DATABASE_URL` if needed. The Google Sheets and Forms APIs are mocked — no external services required.
 
 ---
 
@@ -170,9 +179,10 @@ git checkout -b feature/your-feature
 
 ### Deployment
 
-**Backend (Railway)**
+**Backend (Render)**
 - Root directory: `backend`
 - Start command defined in `Procfile`
+- `DATABASE_URL` points at the Neon Postgres instance
 - Required env vars: `APP_ENV`, `DATABASE_URL`, `API_KEY`, `JWT_SECRET`, `GOOGLE_SERVICE_ACCOUNT_JSON`
 
 **Frontend (Vercel)**
@@ -185,7 +195,7 @@ git checkout -b feature/your-feature
 
 ## Architecture Notes
 
-**Permissions** are membership-based, not role-based. A user can be a tournament director for one tournament and a volunteer in another simultaneously. Access within a tournament is determined by `Membership.positions` (e.g. `tournament_director`, `lead_event_supervisor`) which map to permission keys like `manage_volunteers` and `view_events`.
+**Permissions** are membership-based, not role-based. A user can be a tournament director for one tournament and a volunteer in another simultaneously. Access within a tournament is determined by `TournamentMembership.positions` (e.g. `tournament_director`, `lead_event_supervisor`) which map to permission keys like `manage_volunteers` and `view_events`.
 
 **Sheet sync** upserts users and memberships by email. Contiguous availability slots are merged automatically. Synced volunteers start with no system permissions — TDs assign positions manually.
 

--- a/backend/alembic/versions/a429a58260de_user_profile_and_exp.py
+++ b/backend/alembic/versions/a429a58260de_user_profile_and_exp.py
@@ -41,7 +41,7 @@ def upgrade() -> None:
     op.create_table(
         'event_categories',
         sa.Column('id', sa.Integer(), nullable=False),
-        sa.Column('name', sa.String(length=255), nullable=False),
+        sa.Column('name', sa.String(length=255), unique=True, nullable=False),
         sa.PrimaryKeyConstraint('id'),
     )
     op.create_index('ix_event_categories_id', 'event_categories', ['id'], unique=False)
@@ -50,7 +50,7 @@ def upgrade() -> None:
     op.create_table(
         'events',
         sa.Column('id', sa.Integer(), nullable=False),
-        sa.Column('name', sa.String(length=255), nullable=False),
+        sa.Column('name', sa.String(length=255), unique=True, nullable=False),
         sa.Column('category_id', sa.Integer(), nullable=False),
         sa.ForeignKeyConstraint(['category_id'], ['event_categories.id']),
         sa.PrimaryKeyConstraint('id'),

--- a/backend/alembic/versions/a429a58260de_user_profile_and_exp.py
+++ b/backend/alembic/versions/a429a58260de_user_profile_and_exp.py
@@ -19,7 +19,7 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    # --- users: Task 1 column changes ---
+    # --- users: column changes (add dob, pronouns, etc.) ---
     op.add_column('users', sa.Column('date_of_birth', sa.Date(), nullable=True))
     op.add_column('users', sa.Column('pronouns', sa.String(length=100), nullable=True))
     op.add_column('users', sa.Column('has_competition_experience', sa.Boolean(), nullable=True))
@@ -57,8 +57,26 @@ def upgrade() -> None:
     )
     op.create_index('ix_events_id', 'events', ['id'], unique=False)
 
+    # --- user_competition_experience table ---
+    op.create_table(
+        'user_competition_experience',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('event_id', sa.Integer(), nullable=False),
+        sa.Column('school', sa.String(length=255), nullable=False),
+        sa.Column('notes', sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['event_id'], ['events.id'], ondelete='RESTRICT'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_user_competition_experience_id', 'user_competition_experience', ['id'], unique=False)
+
 
 def downgrade() -> None:
+    # --- drop user_competition_experience ---
+    op.drop_index('ix_user_competition_experience_id', table_name='user_competition_experience')
+    op.drop_table('user_competition_experience')
+
     # --- drop canonical events ---
     op.drop_index('ix_events_id', table_name='events')
     op.drop_table('events')
@@ -75,7 +93,7 @@ def downgrade() -> None:
     op.drop_index('ix_tournament_events_id', table_name='events')
     op.create_index('ix_events_id', 'events', ['id'], unique=False)
 
-    # --- users: reverse Task 1 ---
+    # --- users: reverse users column changes (dob, pronouns, etc.) ---
     op.add_column('users', sa.Column('volunteering_exp', sa.TEXT(), nullable=True))
     op.add_column('users', sa.Column('competition_exp', sa.TEXT(), nullable=True))
     op.drop_column('users', 'has_volunteer_experience')

--- a/backend/alembic/versions/a429a58260de_user_profile_and_exp.py
+++ b/backend/alembic/versions/a429a58260de_user_profile_and_exp.py
@@ -19,6 +19,7 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
+    # --- users: Task 1 column changes ---
     op.add_column('users', sa.Column('date_of_birth', sa.Date(), nullable=True))
     op.add_column('users', sa.Column('pronouns', sa.String(length=100), nullable=True))
     op.add_column('users', sa.Column('has_competition_experience', sa.Boolean(), nullable=True))
@@ -26,10 +27,57 @@ def upgrade() -> None:
     op.drop_column('users', 'competition_exp')
     op.drop_column('users', 'volunteering_exp')
 
+    # --- rename old tournament-scoped events → tournament_events ---
+    op.rename_table('events', 'tournament_events')
+    op.drop_index('ix_events_id', table_name='tournament_events')
+    op.create_index('ix_tournament_events_id', 'tournament_events', ['id'], unique=False)
+
+    # --- rename memberships → tournament_memberships ---
+    op.rename_table('memberships', 'tournament_memberships')
+    op.drop_index('ix_memberships_id', table_name='tournament_memberships')
+    op.create_index('ix_tournament_memberships_id', 'tournament_memberships', ['id'], unique=False)
+
+    # --- canonical event_categories table ---
+    op.create_table(
+        'event_categories',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('name', sa.String(length=255), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_event_categories_id', 'event_categories', ['id'], unique=False)
+
+    # --- canonical events table ---
+    op.create_table(
+        'events',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('name', sa.String(length=255), nullable=False),
+        sa.Column('category_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['category_id'], ['event_categories.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_events_id', 'events', ['id'], unique=False)
+
 
 def downgrade() -> None:
-    op.add_column('users', sa.Column('volunteering_exp', sa.TEXT(), autoincrement=False, nullable=True))
-    op.add_column('users', sa.Column('competition_exp', sa.TEXT(), autoincrement=False, nullable=True))
+    # --- drop canonical events ---
+    op.drop_index('ix_events_id', table_name='events')
+    op.drop_table('events')
+    op.drop_index('ix_event_categories_id', table_name='event_categories')
+    op.drop_table('event_categories')
+
+    # --- rename tournament_memberships → memberships ---
+    op.rename_table('tournament_memberships', 'memberships')
+    op.drop_index('ix_tournament_memberships_id', table_name='memberships')
+    op.create_index('ix_memberships_id', 'memberships', ['id'], unique=False)
+
+    # --- rename tournament_events → events ---
+    op.rename_table('tournament_events', 'events')
+    op.drop_index('ix_tournament_events_id', table_name='events')
+    op.create_index('ix_events_id', 'events', ['id'], unique=False)
+
+    # --- users: reverse Task 1 ---
+    op.add_column('users', sa.Column('volunteering_exp', sa.TEXT(), nullable=True))
+    op.add_column('users', sa.Column('competition_exp', sa.TEXT(), nullable=True))
     op.drop_column('users', 'has_volunteer_experience')
     op.drop_column('users', 'has_competition_experience')
     op.drop_column('users', 'pronouns')

--- a/backend/alembic/versions/a429a58260de_user_profile_and_exp.py
+++ b/backend/alembic/versions/a429a58260de_user_profile_and_exp.py
@@ -71,21 +71,18 @@ def upgrade() -> None:
     )
     op.create_index('ix_user_competition_experience_id', 'user_competition_experience', ['id'], unique=False)
 
-    # --- user_volunteer_experience table ---
+    # --- user_volunteer_experience table (manual pre-NEXUS entries only) ---
     op.create_table(
         'user_volunteer_experience',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('user_id', sa.Integer(), nullable=False),
-        sa.Column('tournament_name', sa.String(length=255), nullable=True),
-        sa.Column('year', sa.Integer(), nullable=True),
+        sa.Column('tournament_name', sa.String(length=255), nullable=False),
+        sa.Column('year', sa.Integer(), nullable=False),
         sa.Column('event_id', sa.Integer(), nullable=True),
-        sa.Column('role', sa.String(length=63), nullable=True),
-        sa.Column('tournament_id', sa.Integer(), nullable=True),
+        sa.Column('role', sa.String(length=63), nullable=False),
         sa.Column('notes', sa.JSON(), nullable=True),
-        sa.Column('is_locked', sa.Boolean(), nullable=False),
         sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
         sa.ForeignKeyConstraint(['event_id'], ['events.id'], ondelete='RESTRICT'),
-        sa.ForeignKeyConstraint(['tournament_id'], ['tournaments.id'], ondelete='CASCADE'),
         sa.PrimaryKeyConstraint('id'),
     )
     op.create_index('ix_user_volunteer_experience_id', 'user_volunteer_experience', ['id'], unique=False)

--- a/backend/alembic/versions/a429a58260de_user_profile_and_exp.py
+++ b/backend/alembic/versions/a429a58260de_user_profile_and_exp.py
@@ -1,0 +1,36 @@
+"""user profile and exp
+
+Revision ID: a429a58260de
+Revises: f250cb93a643
+Create Date: 2026-07-03 13:29:34.804962
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a429a58260de'
+down_revision: Union[str, None] = 'f250cb93a643'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('date_of_birth', sa.Date(), nullable=True))
+    op.add_column('users', sa.Column('pronouns', sa.String(length=100), nullable=True))
+    op.add_column('users', sa.Column('has_competition_experience', sa.Boolean(), nullable=True))
+    op.add_column('users', sa.Column('has_volunteer_experience', sa.Boolean(), nullable=True))
+    op.drop_column('users', 'competition_exp')
+    op.drop_column('users', 'volunteering_exp')
+
+
+def downgrade() -> None:
+    op.add_column('users', sa.Column('volunteering_exp', sa.TEXT(), autoincrement=False, nullable=True))
+    op.add_column('users', sa.Column('competition_exp', sa.TEXT(), autoincrement=False, nullable=True))
+    op.drop_column('users', 'has_volunteer_experience')
+    op.drop_column('users', 'has_competition_experience')
+    op.drop_column('users', 'pronouns')
+    op.drop_column('users', 'date_of_birth')

--- a/backend/alembic/versions/a429a58260de_user_profile_and_exp.py
+++ b/backend/alembic/versions/a429a58260de_user_profile_and_exp.py
@@ -71,8 +71,31 @@ def upgrade() -> None:
     )
     op.create_index('ix_user_competition_experience_id', 'user_competition_experience', ['id'], unique=False)
 
+    # --- user_volunteer_experience table ---
+    op.create_table(
+        'user_volunteer_experience',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('tournament_name', sa.String(length=255), nullable=True),
+        sa.Column('year', sa.Integer(), nullable=True),
+        sa.Column('event_id', sa.Integer(), nullable=True),
+        sa.Column('role', sa.String(length=63), nullable=True),
+        sa.Column('tournament_id', sa.Integer(), nullable=True),
+        sa.Column('notes', sa.JSON(), nullable=True),
+        sa.Column('is_locked', sa.Boolean(), nullable=False),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['event_id'], ['events.id'], ondelete='RESTRICT'),
+        sa.ForeignKeyConstraint(['tournament_id'], ['tournaments.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_user_volunteer_experience_id', 'user_volunteer_experience', ['id'], unique=False)
+
 
 def downgrade() -> None:
+    # --- drop user_volunteer_experience ---
+    op.drop_index('ix_user_volunteer_experience_id', table_name='user_volunteer_experience')
+    op.drop_table('user_volunteer_experience')
+
     # --- drop user_competition_experience ---
     op.drop_index('ix_user_competition_experience_id', table_name='user_competition_experience')
     op.drop_table('user_competition_experience')

--- a/backend/alembic/versions/b92215c62c84_remove_temp_tournament_membership_.py
+++ b/backend/alembic/versions/b92215c62c84_remove_temp_tournament_membership_.py
@@ -1,0 +1,40 @@
+"""remove_temp_tournament_membership_profile_fields
+
+Revision ID: b92215c62c84
+Revises: a429a58260de
+Create Date: 2026-07-20 23:00:25.425825
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b92215c62c84'
+down_revision: Union[str, None] = 'a429a58260de'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_column('tournament_memberships', 'major')
+    op.drop_column('tournament_memberships', 'volunteering_exp')
+    op.drop_column('tournament_memberships', 'dietary_restriction')
+    op.drop_column('tournament_memberships', 'shirt_size')
+    op.drop_column('tournament_memberships', 'university')
+    op.drop_column('tournament_memberships', 'competition_exp')
+    op.drop_column('tournament_memberships', 'employer')
+    op.drop_column('tournament_memberships', 'student_status')
+
+
+def downgrade() -> None:
+    op.add_column('tournament_memberships', sa.Column('student_status', sa.VARCHAR(length=100), autoincrement=False, nullable=True))
+    op.add_column('tournament_memberships', sa.Column('employer', sa.VARCHAR(length=255), autoincrement=False, nullable=True))
+    op.add_column('tournament_memberships', sa.Column('competition_exp', sa.TEXT(), autoincrement=False, nullable=True))
+    op.add_column('tournament_memberships', sa.Column('university', sa.VARCHAR(length=255), autoincrement=False, nullable=True))
+    op.add_column('tournament_memberships', sa.Column('shirt_size', sa.VARCHAR(length=16), autoincrement=False, nullable=True))
+    op.add_column('tournament_memberships', sa.Column('dietary_restriction', sa.VARCHAR(length=255), autoincrement=False, nullable=True))
+    op.add_column('tournament_memberships', sa.Column('volunteering_exp', sa.TEXT(), autoincrement=False, nullable=True))
+    op.add_column('tournament_memberships', sa.Column('major', sa.VARCHAR(length=255), autoincrement=False, nullable=True))

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -12,9 +12,10 @@ from app.core.auth import (
 from app.core.config import get_settings
 from app.core.users import check_if_email_exists, find_user_by_id
 from app.core.email_verification import generate_verification_token, verify_verification_token
+from app.core.profile_status import is_profile_complete
 from app.db.session import get_db
 from app.models.models import User
-from app.schemas.user import UserResponse
+from app.schemas.user import UserMeSlimResponse, UserSlimResponse
 from app.schemas.auth import LoginRequest, RegisterRequest, AdminRegisterRequest, MessageResponse
 from app.services.email_service import send_verification_email
 
@@ -82,7 +83,7 @@ async def _send_verification_email(to: str, id: int):
         raise HTTPException(500, "Failed to send verification email")
 
 
-@router.post("/auth/login/", response_model=UserResponse)
+@router.post("/auth/login/", response_model=UserSlimResponse)
 def login(body: LoginRequest, response: Response, db: Session = Depends(get_db)):
     """
     Authenticate with email + password.
@@ -118,13 +119,13 @@ def logout(response: Response):
     return {"detail": "Logged out"}
 
 
-@router.get("/auth/me/", response_model=UserResponse)
-def me(current_user: User = Depends(get_current_user)):
-    """Return the currently authenticated user."""
-    return current_user
+def me(current_user: User = Depends(get_current_user), db: Session = Depends(get_db)):
+    response = UserMeSlimResponse.model_validate(current_user)
+    response.is_profile_complete = is_profile_complete(current_user, db=db)
+    return response
 
 
-@router.post("/auth/register/", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
+@router.post("/auth/register/", response_model=UserMeSlimResponse, status_code=status.HTTP_201_CREATED)
 def register(body: RegisterRequest, response: Response, db: Session = Depends(get_db)):
     """
     Public route to create a new user account.
@@ -139,7 +140,7 @@ def register(body: RegisterRequest, response: Response, db: Session = Depends(ge
 
     return user
 
-@router.post("/admin/auth/register/", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
+@router.post("/admin/auth/register/", response_model=UserSlimResponse, status_code=status.HTTP_201_CREATED)
 def admin_register(body: AdminRegisterRequest, db: Session = Depends(get_db), _: User = Depends(require_admin)):
     """
     Admin only. Can create normal users and admin users. Password is excluded to allow the newly created user

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -12,10 +12,9 @@ from app.core.auth import (
 from app.core.config import get_settings
 from app.core.users import check_if_email_exists, find_user_by_id
 from app.core.email_verification import generate_verification_token, verify_verification_token
-from app.core.profile_status import is_profile_complete
 from app.db.session import get_db
 from app.models.models import User
-from app.schemas.user import UserMeSlimResponse, UserSlimResponse
+from app.schemas.user import UserSlimResponse
 from app.schemas.auth import LoginRequest, RegisterRequest, AdminRegisterRequest, MessageResponse
 from app.services.email_service import send_verification_email
 
@@ -118,13 +117,6 @@ def logout(response: Response):
     """Clear the auth cookie."""
     _clear_auth_cookie(response)
     return {"detail": "Logged out"}
-
-
-@router.get("/auth/me/", response_model=UserMeSlimResponse)
-def me(current_user: User = Depends(get_current_user), db: Session = Depends(get_db)):
-    response = UserMeSlimResponse.model_validate(current_user)
-    response.is_profile_complete = is_profile_complete(current_user, db=db)
-    return response
 
 
 

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -112,6 +112,7 @@ def login(body: LoginRequest, response: Response, db: Session = Depends(get_db))
     return user
 
 
+
 @router.post("/auth/logout/", status_code=status.HTTP_200_OK)
 def logout(response: Response):
     """Clear the auth cookie."""
@@ -119,13 +120,15 @@ def logout(response: Response):
     return {"detail": "Logged out"}
 
 
+@router.get("/auth/me/", response_model=UserMeSlimResponse)
 def me(current_user: User = Depends(get_current_user), db: Session = Depends(get_db)):
     response = UserMeSlimResponse.model_validate(current_user)
     response.is_profile_complete = is_profile_complete(current_user, db=db)
     return response
 
 
-@router.post("/auth/register/", response_model=UserMeSlimResponse, status_code=status.HTTP_201_CREATED)
+
+@router.post("/auth/register/", response_model=UserSlimResponse, status_code=status.HTTP_201_CREATED)
 def register(body: RegisterRequest, response: Response, db: Session = Depends(get_db)):
     """
     Public route to create a new user account.
@@ -140,6 +143,8 @@ def register(body: RegisterRequest, response: Response, db: Session = Depends(ge
 
     return user
 
+
+
 @router.post("/admin/auth/register/", response_model=UserSlimResponse, status_code=status.HTTP_201_CREATED)
 def admin_register(body: AdminRegisterRequest, db: Session = Depends(get_db), _: User = Depends(require_admin)):
     """
@@ -149,6 +154,8 @@ def admin_register(body: AdminRegisterRequest, db: Session = Depends(get_db), _:
     check_if_email_exists(db, body.email)
 
     return _create_user(db, body.email, body.first_name, body.last_name, body.role, is_active=False)
+
+
 
 @router.get("/auth/verify-email/", status_code=status.HTTP_200_OK, response_model=MessageResponse,
     responses={

--- a/backend/app/api/routes/events.py
+++ b/backend/app/api/routes/events.py
@@ -1,178 +1,144 @@
-from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
 
-from app.core.auth import get_current_user
-from app.core.permissions import (
-    MANAGE_EVENTS,
-    MANAGE_TOURNAMENT,
-    VIEW_EVENTS,
-    require_membership,
-    require_permission,
-    has_permission,
-)
 from app.db.session import get_db
-from app.models.models import Event, Tournament, User
-from app.schemas.event import EventCreate, EventRead, EventUpdate
+from app.models.models import Event, EventCategory, User
+from app.core.auth import require_admin
+from app.schemas.event import (
+    EventResponse, EventCreate, EventUpdate,
+    EventCategoryResponse, EventCategoryCreate, EventCategoryUpdate,
+)
 
-# Routes are nested: /tournaments/{tournament_id}/events/...
-# tournament_id is always present in the path, which drives the permission check.
-router = APIRouter(prefix="/tournaments/{tournament_id}/events", tags=["events"])
-
-
-def _serialize(event: Event) -> dict:
-    return {
-        "id": event.id,
-        "tournament_id": event.tournament_id,
-        "name": event.name,
-        "division": event.division,
-        "event_type": event.event_type,
-        "category": event.category,
-        "building": event.building,
-        "room": event.room,
-        "floor": event.floor,
-        "volunteers_needed": event.volunteers_needed,
-        "blocks": event.blocks or [],
-        "created_at": event.created_at,
-        "updated_at": event.updated_at,
-    }
-
-
-def _get_event_or_404(event_id: int, tournament_id: int, db: Session) -> Event:
-    """
-    Fetch event by ID and validate it belongs to the given tournament.
-    Returns 404 if not found or tournament mismatch — prevents cross-tournament access.
-    """
-    event = db.query(Event).filter(Event.id == event_id).first()
-    if not event:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
-    if event.tournament_id != tournament_id:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
-    return event
-
-
-def _require_write_permission(user: User, tournament_id: int, db: Session) -> None:
-    """Raises 403 unless user has manage_events or manage_tournament."""
-    if not (
-        has_permission(user, tournament_id, MANAGE_EVENTS, db)
-        or has_permission(user, tournament_id, MANAGE_TOURNAMENT, db)
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Insufficient permissions",
-        )
+router = APIRouter(tags=["events"])
 
 
 # ---------------------------------------------------------------------------
-# GET /tournaments/{tournament_id}/events/ — view_events or manage_events
+# GET /events/ — list all events
 # ---------------------------------------------------------------------------
-@router.get("/", response_model=list[EventRead])
-def list_events(
-    tournament_id: int,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(require_permission(VIEW_EVENTS)),
-):
-    """List all events for a tournament, ordered by division then name."""
-    tournament = db.query(Tournament).filter(Tournament.id == tournament_id).first()
-    if not tournament:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tournament not found")
-
-    events = (
-        db.query(Event)
-        .filter(Event.tournament_id == tournament_id)
-        .order_by(Event.division, Event.name)
-        .all()
-    )
-    return [_serialize(e) for e in events]
+@router.get("/events/", response_model=list[EventResponse])
+def list_events(db: Session = Depends(get_db)):
+    return db.query(Event).all()
 
 
 # ---------------------------------------------------------------------------
-# GET /tournaments/{tournament_id}/events/{event_id} — view_events or manage_events
+# POST /events/ — admin only, create a new event
 # ---------------------------------------------------------------------------
-@router.get("/{event_id}/", response_model=EventRead)
-def get_event(
-    tournament_id: int,
-    event_id: int,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(require_permission(VIEW_EVENTS)),
-):
-    return _serialize(_get_event_or_404(event_id, tournament_id, db))
+@router.post("/events/", response_model=EventResponse, status_code=status.HTTP_201_CREATED)
+def create_event(body: EventCreate, db: Session = Depends(get_db), _: User = Depends(require_admin)):
+    category = db.get(EventCategory, body.category_id)
+    if not category:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Category not found")
 
-
-# ---------------------------------------------------------------------------
-# POST /tournaments/{tournament_id}/events/ — manage_events or manage_tournament
-# ---------------------------------------------------------------------------
-@router.post("/", response_model=EventRead, status_code=status.HTTP_201_CREATED)
-def create_event(
-    tournament_id: int,
-    payload: EventCreate,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-):
-    _require_write_permission(current_user, tournament_id, db)
-
-    # Validate tournament_id in body matches path
-    if payload.tournament_id != tournament_id:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="tournament_id in body does not match URL",
-        )
-
-    tournament = db.query(Tournament).filter(Tournament.id == tournament_id).first()
-    if not tournament:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tournament not found")
-
-    existing = db.query(Event).filter(
-        Event.tournament_id == tournament_id,
-        Event.name == payload.name,
-        Event.division == payload.division,
-    ).first()
-    if existing:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=f"Event '{payload.name}' division {payload.division} already exists in this tournament",
-        )
-
-    event = Event(**payload.model_dump())
+    event = Event(name=body.name, category_id=body.category_id)
     db.add(event)
     db.commit()
     db.refresh(event)
-    return _serialize(event)
+    return event
 
 
 # ---------------------------------------------------------------------------
-# PATCH /tournaments/{tournament_id}/events/{event_id} — manage_events or manage_tournament
+# PATCH /events/{id}/ — admin only, partial update
 # ---------------------------------------------------------------------------
-@router.patch("/{event_id}/", response_model=EventRead)
-def update_event(
-    tournament_id: int,
-    event_id: int,
-    payload: EventUpdate,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-):
-    _require_write_permission(current_user, tournament_id, db)
-    event = _get_event_or_404(event_id, tournament_id, db)
+@router.patch("/events/{event_id}/", response_model=EventResponse)
+def update_event(event_id: int, body: EventUpdate, db: Session = Depends(get_db), _: User = Depends(require_admin)):
+    event = db.get(Event, event_id)
+    if not event:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
 
-    for field, value in payload.model_dump(exclude_none=True).items():
+    data = body.model_dump(exclude_unset=True)
+
+    if "category_id" in data:
+        category = db.get(EventCategory, data["category_id"])
+        if not category:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Category not found")
+
+    for field, value in data.items():
         setattr(event, field, value)
 
     db.commit()
     db.refresh(event)
-    return _serialize(event)
+    return event
 
 
 # ---------------------------------------------------------------------------
-# DELETE /tournaments/{tournament_id}/events/{event_id} — manage_events or manage_tournament
+# DELETE /events/{id}/ — admin only, hard delete blocked if experience entries exist
 # ---------------------------------------------------------------------------
-@router.delete("/{event_id}/", status_code=status.HTTP_204_NO_CONTENT)
-def delete_event(
-    tournament_id: int,
-    event_id: int,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-):
-    _require_write_permission(current_user, tournament_id, db)
-    event = _get_event_or_404(event_id, tournament_id, db)
+@router.delete("/events/{event_id}/", status_code=status.HTTP_204_NO_CONTENT)
+def delete_event(event_id: int, db: Session = Depends(get_db), _: User = Depends(require_admin)):
+    event = db.get(Event, event_id)
+    if not event:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
+
     db.delete(event)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Cannot delete event: it has associated competition or volunteer experience entries",
+        )
+
+
+# ---------------------------------------------------------------------------
+# GET /event-categories/ — list all event categories
+# ---------------------------------------------------------------------------
+@router.get("/event-categories/", response_model=list[EventCategoryResponse])
+def list_event_categories(db: Session = Depends(get_db)):
+    return db.query(EventCategory).all()
+
+
+# ---------------------------------------------------------------------------
+# POST /event-categories/ — admin only, create a new category
+# ---------------------------------------------------------------------------
+@router.post("/event-categories/", response_model=EventCategoryResponse, status_code=status.HTTP_201_CREATED)
+def create_event_category(body: EventCategoryCreate, db: Session = Depends(get_db), _: User = Depends(require_admin)):
+    category = EventCategory(name=body.name)
+    db.add(category)
     db.commit()
+    db.refresh(category)
+    return category
+
+
+# ---------------------------------------------------------------------------
+# PATCH /event-categories/{id}/ — admin only, partial update
+# ---------------------------------------------------------------------------
+@router.patch("/event-categories/{category_id}/", response_model=EventCategoryResponse)
+def update_event_category(
+    category_id: int,
+    body: EventCategoryUpdate,
+    db: Session = Depends(get_db),
+    _: User = Depends(require_admin),
+):
+    category = db.get(EventCategory, category_id)
+    if not category:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Category not found")
+
+    for field, value in body.model_dump(exclude_unset=True).items():
+        setattr(category, field, value)
+
+    db.commit()
+    db.refresh(category)
+    return category
+
+
+# ---------------------------------------------------------------------------
+# DELETE /event-categories/{id}/ — admin only, cascades to delete its events
+# (blocked if any of those events has experience entries — see delete_event note)
+# ---------------------------------------------------------------------------
+@router.delete("/event-categories/{category_id}/", status_code=status.HTTP_204_NO_CONTENT)
+def delete_event_category(category_id: int, db: Session = Depends(get_db), _: User = Depends(require_admin)):
+    category = db.get(EventCategory, category_id)
+    if not category:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Category not found")
+
+    db.delete(category)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Cannot delete category: one or more of its events has associated experience entries",
+        )

--- a/backend/app/api/routes/tournament_events.py
+++ b/backend/app/api/routes/tournament_events.py
@@ -17,7 +17,7 @@ from app.schemas.tournament_event import EventCreate, EventRead, EventUpdate
 
 # Routes are nested: /tournaments/{tournament_id}/events/...
 # tournament_id is always present in the path, which drives the permission check.
-router = APIRouter(prefix="/tournaments/{tournament_id}/events", tags=["events"])
+router = APIRouter(prefix="/tournaments/{tournament_id}/events", tags=["tournaments"])
 
 
 def _serialize(event: TournamentEvent) -> dict:

--- a/backend/app/api/routes/tournament_events.py
+++ b/backend/app/api/routes/tournament_events.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.core.auth import get_current_user
+from app.core.permissions import (
+    MANAGE_EVENTS,
+    MANAGE_TOURNAMENT,
+    VIEW_EVENTS,
+    require_membership,
+    require_permission,
+    has_permission,
+)
+from app.db.session import get_db
+from app.models.models import Event, Tournament, User
+from backend.app.schemas.tournament_event import EventCreate, EventRead, EventUpdate
+
+# Routes are nested: /tournaments/{tournament_id}/events/...
+# tournament_id is always present in the path, which drives the permission check.
+router = APIRouter(prefix="/tournaments/{tournament_id}/events", tags=["events"])
+
+
+def _serialize(event: Event) -> dict:
+    return {
+        "id": event.id,
+        "tournament_id": event.tournament_id,
+        "name": event.name,
+        "division": event.division,
+        "event_type": event.event_type,
+        "category": event.category,
+        "building": event.building,
+        "room": event.room,
+        "floor": event.floor,
+        "volunteers_needed": event.volunteers_needed,
+        "blocks": event.blocks or [],
+        "created_at": event.created_at,
+        "updated_at": event.updated_at,
+    }
+
+
+def _get_event_or_404(event_id: int, tournament_id: int, db: Session) -> Event:
+    """
+    Fetch event by ID and validate it belongs to the given tournament.
+    Returns 404 if not found or tournament mismatch — prevents cross-tournament access.
+    """
+    event = db.query(Event).filter(Event.id == event_id).first()
+    if not event:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
+    if event.tournament_id != tournament_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
+    return event
+
+
+def _require_write_permission(user: User, tournament_id: int, db: Session) -> None:
+    """Raises 403 unless user has manage_events or manage_tournament."""
+    if not (
+        has_permission(user, tournament_id, MANAGE_EVENTS, db)
+        or has_permission(user, tournament_id, MANAGE_TOURNAMENT, db)
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Insufficient permissions",
+        )
+
+
+# ---------------------------------------------------------------------------
+# GET /tournaments/{tournament_id}/events/ — view_events or manage_events
+# ---------------------------------------------------------------------------
+@router.get("/", response_model=list[EventRead])
+def list_events(
+    tournament_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_permission(VIEW_EVENTS)),
+):
+    """List all events for a tournament, ordered by division then name."""
+    tournament = db.query(Tournament).filter(Tournament.id == tournament_id).first()
+    if not tournament:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tournament not found")
+
+    events = (
+        db.query(Event)
+        .filter(Event.tournament_id == tournament_id)
+        .order_by(Event.division, Event.name)
+        .all()
+    )
+    return [_serialize(e) for e in events]
+
+
+# ---------------------------------------------------------------------------
+# GET /tournaments/{tournament_id}/events/{event_id} — view_events or manage_events
+# ---------------------------------------------------------------------------
+@router.get("/{event_id}/", response_model=EventRead)
+def get_event(
+    tournament_id: int,
+    event_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_permission(VIEW_EVENTS)),
+):
+    return _serialize(_get_event_or_404(event_id, tournament_id, db))
+
+
+# ---------------------------------------------------------------------------
+# POST /tournaments/{tournament_id}/events/ — manage_events or manage_tournament
+# ---------------------------------------------------------------------------
+@router.post("/", response_model=EventRead, status_code=status.HTTP_201_CREATED)
+def create_event(
+    tournament_id: int,
+    payload: EventCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    _require_write_permission(current_user, tournament_id, db)
+
+    # Validate tournament_id in body matches path
+    if payload.tournament_id != tournament_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="tournament_id in body does not match URL",
+        )
+
+    tournament = db.query(Tournament).filter(Tournament.id == tournament_id).first()
+    if not tournament:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tournament not found")
+
+    existing = db.query(Event).filter(
+        Event.tournament_id == tournament_id,
+        Event.name == payload.name,
+        Event.division == payload.division,
+    ).first()
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Event '{payload.name}' division {payload.division} already exists in this tournament",
+        )
+
+    event = Event(**payload.model_dump())
+    db.add(event)
+    db.commit()
+    db.refresh(event)
+    return _serialize(event)
+
+
+# ---------------------------------------------------------------------------
+# PATCH /tournaments/{tournament_id}/events/{event_id} — manage_events or manage_tournament
+# ---------------------------------------------------------------------------
+@router.patch("/{event_id}/", response_model=EventRead)
+def update_event(
+    tournament_id: int,
+    event_id: int,
+    payload: EventUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    _require_write_permission(current_user, tournament_id, db)
+    event = _get_event_or_404(event_id, tournament_id, db)
+
+    for field, value in payload.model_dump(exclude_none=True).items():
+        setattr(event, field, value)
+
+    db.commit()
+    db.refresh(event)
+    return _serialize(event)
+
+
+# ---------------------------------------------------------------------------
+# DELETE /tournaments/{tournament_id}/events/{event_id} — manage_events or manage_tournament
+# ---------------------------------------------------------------------------
+@router.delete("/{event_id}/", status_code=status.HTTP_204_NO_CONTENT)
+def delete_event(
+    tournament_id: int,
+    event_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    _require_write_permission(current_user, tournament_id, db)
+    event = _get_event_or_404(event_id, tournament_id, db)
+    db.delete(event)
+    db.commit()

--- a/backend/app/api/routes/tournament_events.py
+++ b/backend/app/api/routes/tournament_events.py
@@ -12,15 +12,15 @@ from app.core.permissions import (
     has_permission,
 )
 from app.db.session import get_db
-from app.models.models import Event, Tournament, User
-from backend.app.schemas.tournament_event import EventCreate, EventRead, EventUpdate
+from app.models.models import TournamentEvent, Tournament, User
+from app.schemas.tournament_event import EventCreate, EventRead, EventUpdate
 
 # Routes are nested: /tournaments/{tournament_id}/events/...
 # tournament_id is always present in the path, which drives the permission check.
 router = APIRouter(prefix="/tournaments/{tournament_id}/events", tags=["events"])
 
 
-def _serialize(event: Event) -> dict:
+def _serialize(event: TournamentEvent) -> dict:
     return {
         "id": event.id,
         "tournament_id": event.tournament_id,
@@ -38,12 +38,12 @@ def _serialize(event: Event) -> dict:
     }
 
 
-def _get_event_or_404(event_id: int, tournament_id: int, db: Session) -> Event:
+def _get_event_or_404(event_id: int, tournament_id: int, db: Session) -> TournamentEvent:
     """
     Fetch event by ID and validate it belongs to the given tournament.
     Returns 404 if not found or tournament mismatch — prevents cross-tournament access.
     """
-    event = db.query(Event).filter(Event.id == event_id).first()
+    event = db.query(TournamentEvent).filter(TournamentEvent.id == event_id).first()
     if not event:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
     if event.tournament_id != tournament_id:
@@ -78,9 +78,9 @@ def list_events(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tournament not found")
 
     events = (
-        db.query(Event)
-        .filter(Event.tournament_id == tournament_id)
-        .order_by(Event.division, Event.name)
+        db.query(TournamentEvent)
+        .filter(TournamentEvent.tournament_id == tournament_id)
+        .order_by(TournamentEvent.division, TournamentEvent.name)
         .all()
     )
     return [_serialize(e) for e in events]
@@ -122,10 +122,10 @@ def create_event(
     if not tournament:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tournament not found")
 
-    existing = db.query(Event).filter(
-        Event.tournament_id == tournament_id,
-        Event.name == payload.name,
-        Event.division == payload.division,
+    existing = db.query(TournamentEvent).filter(
+        TournamentEvent.tournament_id == tournament_id,
+        TournamentEvent.name == payload.name,
+        TournamentEvent.division == payload.division,
     ).first()
     if existing:
         raise HTTPException(
@@ -133,7 +133,7 @@ def create_event(
             detail=f"Event '{payload.name}' division {payload.division} already exists in this tournament",
         )
 
-    event = Event(**payload.model_dump())
+    event = TournamentEvent(**payload.model_dump())
     db.add(event)
     db.commit()
     db.refresh(event)

--- a/backend/app/api/routes/tournament_memberships.py
+++ b/backend/app/api/routes/tournament_memberships.py
@@ -11,7 +11,7 @@ from app.core.permissions import (
 )
 from app.db.session import get_db
 from app.models.models import Event, Membership, Tournament, User
-from app.schemas.membership import MembershipCreate, MembershipRead, MembershipUpdate, MembershipReadFlat
+from backend.app.schemas.tournament_membership import MembershipCreate, MembershipRead, MembershipUpdate, MembershipReadFlat
 
 # Routes nested: /tournaments/{tournament_id}/memberships/...
 router = APIRouter(prefix="/tournaments/{tournament_id}/memberships", tags=["memberships"])

--- a/backend/app/api/routes/tournament_memberships.py
+++ b/backend/app/api/routes/tournament_memberships.py
@@ -14,7 +14,7 @@ from app.models.models import Event, TournamentMembership, Tournament, User
 from app.schemas.tournament_membership import MembershipCreate, MembershipRead, MembershipUpdate, MembershipReadFlat
 
 # Routes nested: /tournaments/{tournament_id}/memberships/...
-router = APIRouter(prefix="/tournaments/{tournament_id}/memberships", tags=["memberships"])
+router = APIRouter(prefix="/tournaments/{tournament_id}/memberships", tags=["tournaments"])
 
 
 def _serialize(m: TournamentMembership, include_user: bool = False) -> dict:

--- a/backend/app/api/routes/tournament_memberships.py
+++ b/backend/app/api/routes/tournament_memberships.py
@@ -10,14 +10,14 @@ from app.core.permissions import (
     require_permission,
 )
 from app.db.session import get_db
-from app.models.models import Event, Membership, Tournament, User
-from backend.app.schemas.tournament_membership import MembershipCreate, MembershipRead, MembershipUpdate, MembershipReadFlat
+from app.models.models import Event, TournamentMembership, Tournament, User
+from app.schemas.tournament_membership import MembershipCreate, MembershipRead, MembershipUpdate, MembershipReadFlat
 
 # Routes nested: /tournaments/{tournament_id}/memberships/...
 router = APIRouter(prefix="/tournaments/{tournament_id}/memberships", tags=["memberships"])
 
 
-def _serialize(m: Membership, include_user: bool = False) -> dict:
+def _serialize(m: TournamentMembership, include_user: bool = False) -> dict:
     """Serialize membership, converting availability and schedule slots to dicts.
 
     Pass include_user=True in list views to embed user name/email inline,
@@ -83,9 +83,9 @@ def _require_write_permission(user: User, tournament_id: int, db: Session) -> No
         )
 
 
-def _get_membership_or_404(membership_id: int, tournament_id: int, db: Session) -> Membership:
+def _get_membership_or_404(membership_id: int, tournament_id: int, db: Session) -> TournamentMembership:
     """Fetch membership and validate it belongs to the given tournament."""
-    m = db.query(Membership).filter(Membership.id == membership_id).first()
+    m = db.query(TournamentMembership).filter(TournamentMembership.id == membership_id).first()
     if not m:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Membership not found")
     if m.tournament_id != tournament_id:
@@ -117,19 +117,19 @@ def list_memberships(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tournament not found")
 
     query = (
-        db.query(Membership)
-        .options(joinedload(Membership.user))
-        .filter(Membership.tournament_id == tournament_id)
+        db.query(TournamentMembership)
+        .options(joinedload(TournamentMembership.user))
+        .filter(TournamentMembership.tournament_id == tournament_id)
     )
     if status_filter:
-        query = query.filter(Membership.status == status_filter)
+        query = query.filter(TournamentMembership.status == status_filter)
 
     results = []
-    for m in query.order_by(Membership.id).all():
+    for m in query.order_by(TournamentMembership.id).all():
         data = _serialize(m)
         # TODO(temp): these fields are sourced from User — when the user profile
         # page is built, the full user profile (beyond identity) should continue
-        # to come from User, not Membership.
+        # to come from User, not TournamentMembership.
         data["first_name"] = m.user.first_name if m.user else None
         data["last_name"] = m.user.last_name if m.user else None
         data["email"] = m.user.email if m.user else None
@@ -188,9 +188,9 @@ def create_membership(
         if not event:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found in this tournament")
 
-    existing = db.query(Membership).filter(
-        Membership.user_id == payload.user_id,
-        Membership.tournament_id == tournament_id,
+    existing = db.query(TournamentMembership).filter(
+        TournamentMembership.user_id == payload.user_id,
+        TournamentMembership.tournament_id == tournament_id,
     ).first()
     if existing:
         raise HTTPException(
@@ -204,7 +204,7 @@ def create_membership(
     if data.get("schedule"):
         data["schedule"] = [s.model_dump() for s in payload.schedule]
 
-    membership = Membership(**data)
+    membership = TournamentMembership(**data)
     db.add(membership)
     db.commit()
     db.refresh(membership)

--- a/backend/app/api/routes/tournaments.py
+++ b/backend/app/api/routes/tournaments.py
@@ -10,7 +10,7 @@ from app.core.permissions import (
     has_any_membership,
 )
 from app.db.session import get_db
-from app.models.models import Membership, Tournament, User
+from app.models.models import TournamentMembership, Tournament, User
 from app.schemas.tournament import TournamentCreate, TournamentRead, TournamentUpdate
 
 router = APIRouter(prefix="/tournaments", tags=["tournaments"])
@@ -71,8 +71,8 @@ def list_my_tournaments(
     else:
         tournaments = (
             db.query(Tournament)
-            .join(Membership, Membership.tournament_id == Tournament.id)
-            .filter(Membership.user_id == current_user.id)
+            .join(TournamentMembership, TournamentMembership.tournament_id == Tournament.id)
+            .filter(TournamentMembership.user_id == current_user.id)
             .order_by(Tournament.created_at.desc())
             .all()
         )
@@ -105,7 +105,7 @@ def create_tournament(
     db.flush()  # get tournament.id before creating membership
 
     # Auto-create a tournament_director membership for the creator.
-    membership = Membership(
+    membership = TournamentMembership(
         user_id=current_user.id,
         tournament_id=tournament.id,
         positions=["tournament_director"],

--- a/backend/app/api/routes/user_experience.py
+++ b/backend/app/api/routes/user_experience.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.core.auth import get_current_user
+from app.db.session import get_db
+from app.models.models import User, Event, UserCompetitionExperience, UserVolunteerExperience
+from app.schemas.user_experience import (
+    CompetitionExperienceCreate, CompetitionExperienceUpdate, CompetitionExperienceResponse,
+    VolunteerExperienceCreate, VolunteerExperienceUpdate, VolunteerExperienceResponse
+)
+
+
+router = APIRouter(tags=["user-exp"])
+
+
+# ---------------------------------------------------------------------------
+# POST /users/me/competition-experience/ — add a competition experience entry
+# ---------------------------------------------------------------------------
+@router.post("/users/me/competition-experience/", response_model=CompetitionExperienceResponse, status_code=status.HTTP_201_CREATED)
+def create_competition_experience(
+    body: CompetitionExperienceCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    event = db.get(Event, body.event_id)
+    if not event:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
+
+    entry = UserCompetitionExperience(user_id=current_user.id, **body.model_dump())
+    db.add(entry)
+    db.commit()
+    db.refresh(entry)
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# PATCH /users/me/competition-experience/{id}/ — update own entry
+# ---------------------------------------------------------------------------
+@router.patch("/users/me/competition-experience/{entry_id}/", response_model=CompetitionExperienceResponse)
+def update_competition_experience(
+    entry_id: int,
+    body: CompetitionExperienceUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    entry = db.get(UserCompetitionExperience, entry_id)
+    if not entry or entry.user_id != current_user.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Entry not found")
+
+    data = body.model_dump(exclude_unset=True)
+    if "event_id" in data:
+        event = db.get(Event, data["event_id"])
+        if not event:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
+
+    for field, value in data.items():
+        setattr(entry, field, value)
+
+    db.commit()
+    db.refresh(entry)
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# DELETE /users/me/competition-experience/{id}/ — delete own entry
+# ---------------------------------------------------------------------------
+@router.delete("/users/me/competition-experience/{entry_id}/", status_code=status.HTTP_204_NO_CONTENT)
+def delete_competition_experience(
+    entry_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    entry = db.get(UserCompetitionExperience, entry_id)
+    if not entry or entry.user_id != current_user.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Entry not found")
+
+    db.delete(entry)
+    db.commit()
+
+
+
+# ---------------------------------------------------------------------------
+# POST /users/me/volunteer-experience/ — add a volunteer experience entry
+# (manual entry only — see model note: auto-populate from NEXUS is future work)
+# ---------------------------------------------------------------------------
+@router.post("/users/me/volunteer-experience/", response_model=VolunteerExperienceResponse, status_code=status.HTTP_201_CREATED)
+def create_volunteer_experience(
+    body: VolunteerExperienceCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    if body.event_id is not None:
+        event = db.get(Event, body.event_id)
+        if not event:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
+
+    entry = UserVolunteerExperience(
+        user_id=current_user.id,
+        tournament_name=body.tournament_name,
+        year=body.year,
+        event_id=body.event_id,
+        role=body.role,
+        notes=body.notes.model_dump(exclude_none=True) if body.notes else None,
+    )
+    db.add(entry)
+    db.commit()
+    db.refresh(entry)
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# PATCH /users/me/volunteer-experience/{id}/ — update own entry
+# ---------------------------------------------------------------------------
+@router.patch("/users/me/volunteer-experience/{entry_id}/", response_model=VolunteerExperienceResponse)
+def update_volunteer_experience(
+    entry_id: int,
+    body: VolunteerExperienceUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    entry = db.get(UserVolunteerExperience, entry_id)
+    if not entry or entry.user_id != current_user.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Entry not found")
+
+    data = body.model_dump(exclude_unset=True)
+
+    if "event_id" in data and data["event_id"] is not None:
+        event = db.get(Event, data["event_id"])
+        if not event:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
+
+    # re-check mutual exclusivity against the merged post-update state
+    resulting_event_id = data.get("event_id", entry.event_id)
+    resulting_notes = data.get("notes", entry.notes)
+    resulting_notes_event = resulting_notes.get("event") if isinstance(resulting_notes, dict) else None
+    if resulting_event_id is not None and resulting_notes_event:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="event_id and notes.event are mutually exclusive",
+        )
+
+    if "notes" in data:
+        data["notes"] = data["notes"].model_dump(exclude_none=True) if data["notes"] else None
+
+    for field, value in data.items():
+        setattr(entry, field, value)
+
+    db.commit()
+    db.refresh(entry)
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# DELETE /users/me/volunteer-experience/{id}/ — delete own entry
+# ---------------------------------------------------------------------------
+@router.delete("/users/me/volunteer-experience/{entry_id}/", status_code=status.HTTP_204_NO_CONTENT)
+def delete_volunteer_experience(
+    entry_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    entry = db.get(UserVolunteerExperience, entry_id)
+    if not entry or entry.user_id != current_user.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Entry not found")
+
+    db.delete(entry)
+    db.commit()

--- a/backend/app/api/routes/user_experience.py
+++ b/backend/app/api/routes/user_experience.py
@@ -11,7 +11,7 @@ from app.schemas.user_experience import (
 )
 
 
-router = APIRouter(tags=["user-exp"])
+router = APIRouter(tags=["users"])
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -117,7 +117,7 @@ def update_user_me(
     """
     for field, value in body.model_dump(exclude_unset=True).items():
         if field == "email":
-            check_if_email_exists(db, body.email)
+            check_if_email_exists(db, body.email, exclude_user_id=user.id)
         setattr(user, field, value)
     db.commit()
     db.refresh(user)

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -3,11 +3,11 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.core.auth import get_current_user, require_admin
-from app.core.permissions import MANAGE_TOURNAMENT, MANAGE_VOLUNTEERS, has_permission
 from app.core.users import check_if_email_exists, find_user_by_id
+from app.core.profile_status import compute_missing_profile_fields
 from app.db.session import get_db
-from app.models.models import Membership, User
-from app.schemas.user import UserResponse, UserUpdate, AdminUserUpdate
+from app.models.models import User
+from app.schemas.user import UserFullResponse, UserMeFullResponse, UserSlimResponse, UserUpdate, AdminUserUpdate
 
 router = APIRouter(tags=["users"])
 
@@ -15,7 +15,7 @@ router = APIRouter(tags=["users"])
 # ---------------------------------------------------------------------------
 # GET /users/ — admin only (global unscoped list)
 # ---------------------------------------------------------------------------
-@router.get("/admin/users/", response_model=list[UserResponse])
+@router.get("/admin/users/", response_model=list[UserSlimResponse])
 def list_users(
     db: Session = Depends(get_db),
     _: User = Depends(require_admin),
@@ -27,7 +27,7 @@ def list_users(
 # ---------------------------------------------------------------------------
 # GET /users/{user_id}/ — admin only
 # ---------------------------------------------------------------------------
-@router.get("/admin/users/{user_id}/", response_model=UserResponse)
+@router.get("/admin/users/{user_id}/", response_model=UserFullResponse)
 def get_user(
     user_id: int,
     db: Session = Depends(get_db),
@@ -43,7 +43,7 @@ def get_user(
 # ---------------------------------------------------------------------------
 # GET /users/by-email/{email}/ — admin only
 # ---------------------------------------------------------------------------
-@router.get("/admin/users/by-email/{email}/", response_model=UserResponse)
+@router.get("/admin/users/by-email/{email}/", response_model=UserFullResponse)
 def get_user_by_email(
     email: str,
     db: Session = Depends(get_db),
@@ -59,7 +59,7 @@ def get_user_by_email(
 # ---------------------------------------------------------------------------
 # PATCH /admin/users/{user_id}/ — admin only
 # ---------------------------------------------------------------------------
-@router.patch("/admin/users/{user_id}/", response_model=UserResponse)
+@router.patch("/admin/users/{user_id}/", response_model=UserSlimResponse)
 def admin_update_user(
     user_id: int,
     body: AdminUserUpdate,
@@ -92,48 +92,19 @@ def admin_delete_user(
 
 
 # ---------------------------------------------------------------------------
-# GET /tournaments/{tournament_id}/users/{user_id}
-# Requires manage_volunteers or manage_tournament for that tournament.
+# GET /users/me/
 # ---------------------------------------------------------------------------
-@router.get("/tournaments/{tournament_id}/users/{user_id}/", response_model=UserResponse)
-def get_tournament_user(
-    tournament_id: int,
-    user_id: int,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-):
-    """
-    Get a specific user who is a member of a tournament.
-    Requires manage_volunteers or manage_tournament in that tournament.
-    Returns 404 if the user is not a member of the tournament.
-    """
-    if not (
-        has_permission(current_user, tournament_id, MANAGE_VOLUNTEERS, db)
-        or has_permission(current_user, tournament_id, MANAGE_TOURNAMENT, db)
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Insufficient permissions",
-        )
-
-    # Verify the user actually has a membership in this tournament
-    membership = db.query(Membership).filter(
-        Membership.user_id == user_id,
-        Membership.tournament_id == tournament_id,
-    ).first()
-    if not membership:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found in this tournament")
-
-    user = db.query(User).filter(User.id == user_id).first()
-    if not user:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
-    return user
+@router.get("/users/me/", response_model=UserMeFullResponse)
+def get_me(current_user: User = Depends(get_current_user)):
+    response = UserMeFullResponse.model_validate(current_user)
+    response.missing_profile_fields = compute_missing_profile_fields(current_user)
+    return response
 
 
 # ---------------------------------------------------------------------------
 # PATCH /users/me/ — authenticated user updates their own profile
 # ---------------------------------------------------------------------------
-@router.patch("/users/me/", response_model=UserResponse)
+@router.patch("/users/me/", response_model=UserMeFullResponse)
 def update_user_me(
     body: UserUpdate,
     db: Session = Depends(get_db),
@@ -150,4 +121,7 @@ def update_user_me(
         setattr(user, field, value)
     db.commit()
     db.refresh(user)
-    return user
+    
+    response = UserMeFullResponse.model_validate(user)
+    response.missing_profile_fields = compute_missing_profile_fields(user, db=db)
+    return response

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
+from typing import Union
 
 from app.core.auth import get_current_user, require_admin
 from app.core.users import check_if_email_exists, find_user_by_id
-from app.core.profile_status import compute_missing_profile_fields
+from app.core.profile_status import compute_missing_profile_fields, is_profile_complete
 from app.db.session import get_db
 from app.models.models import User
-from app.schemas.user import UserFullResponse, UserMeFullResponse, UserSlimResponse, UserUpdate, AdminUserUpdate
+from app.schemas.user import (
+    UserFullResponse, UserMeFullResponse, UserSlimResponse,
+    UserMeSlimResponse, UserUpdate, AdminUserUpdate
+)
 
 router = APIRouter(tags=["users"])
 
@@ -92,12 +96,28 @@ def admin_delete_user(
 
 
 # ---------------------------------------------------------------------------
-# GET /users/me/
+# GET /users/me/ — current user's own profile. ?full=true for full response
+# with experience lists eagerly loaded.
 # ---------------------------------------------------------------------------
-@router.get("/users/me/", response_model=UserMeFullResponse)
-def get_me(current_user: User = Depends(get_current_user)):
-    response = UserMeFullResponse.model_validate(current_user)
-    response.missing_profile_fields = compute_missing_profile_fields(current_user)
+@router.get("/users/me/", response_model=Union[UserMeFullResponse, UserMeSlimResponse])
+def get_me(
+    full: bool = False,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    if full:
+        user = (
+            db.query(User)
+            .options(selectinload(User.competition_experience), selectinload(User.volunteer_experience))
+            .filter(User.id == current_user.id)
+            .first()
+        )
+        response = UserMeFullResponse.model_validate(user)
+        response.missing_profile_fields = compute_missing_profile_fields(user)  # relationships loaded, no db needed
+        return response
+
+    response = UserMeSlimResponse.model_validate(current_user)
+    response.is_profile_complete = is_profile_complete(current_user, db=db)
     return response
 
 

--- a/backend/app/core/age.py
+++ b/backend/app/core/age.py
@@ -1,0 +1,7 @@
+from datetime import date
+
+def calculate_age(birth_date: date, reference_date: date) -> int:
+    return reference_date.year - birth_date.year - ((reference_date.month, reference_date.day) < (birth_date.month, birth_date.day))
+
+def meets_age_requirement(birth_date: date, reference_date: date, min_age: int) -> bool:
+    return calculate_age(birth_date, reference_date) >= min_age

--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -162,16 +162,16 @@ def get_user_permissions(
 
     Returns an empty set if the user has no membership in this tournament.
     """
-    from app.models.models import Membership, Tournament
+    from app.models.models import TournamentMembership, Tournament
 
     if user.role == "admin":
         return set(ALL_PERMISSIONS)
 
     membership = (
-        db.query(Membership)
+        db.query(TournamentMembership)
         .filter(
-            Membership.user_id == user.id,
-            Membership.tournament_id == tournament_id,
+            TournamentMembership.user_id == user.id,
+            TournamentMembership.tournament_id == tournament_id,
         )
         .first()
     )
@@ -221,16 +221,16 @@ def has_any_membership(
     db: Session,
 ) -> bool:
     """Return True if the user has any membership in `tournament_id`."""
-    from app.models.models import Membership
+    from app.models.models import TournamentMembership
 
     if user.role == "admin":
         return True
 
     return (
-        db.query(Membership)
+        db.query(TournamentMembership)
         .filter(
-            Membership.user_id == user.id,
-            Membership.tournament_id == tournament_id,
+            TournamentMembership.user_id == user.id,
+            TournamentMembership.tournament_id == tournament_id,
         )
         .first()
     ) is not None

--- a/backend/app/core/profile_status.py
+++ b/backend/app/core/profile_status.py
@@ -12,6 +12,13 @@ def _has_competition_rows(user: User, db: Optional[Session]) -> bool:
 
 
 def _has_volunteer_rows(user: User, db: Optional[Session]) -> bool:
+    """
+    Manual entries ONLY — intentionally does not include NEXUS-synthesized rows
+    (from TournamentMembership, once that integration exists).
+    has_volunteer_experience reflects whether the user intends to log manual
+    entries, independent of any auto-populated tournament history. Do not change
+    this to query a merged/synthesized experience list.
+    """
     if db is not None:
         return db.query(
             db.query(UserVolunteerExperience).filter_by(user_id=user.id).exists()

--- a/backend/app/core/profile_status.py
+++ b/backend/app/core/profile_status.py
@@ -1,0 +1,50 @@
+from sqlalchemy.orm import Session
+from typing import Optional
+
+from app.models.models import User, UserCompetitionExperience, UserVolunteerExperience
+
+def _has_competition_rows(user: User, db: Optional[Session]) -> bool:
+    if db is not None:
+        return db.query(
+            db.query(UserCompetitionExperience).filter_by(user_id=user.id).exists()
+        ).scalar()
+    return bool(user.competition_experience)
+
+
+def _has_volunteer_rows(user: User, db: Optional[Session]) -> bool:
+    if db is not None:
+        return db.query(
+            db.query(UserVolunteerExperience).filter_by(user_id=user.id).exists()
+        ).scalar()
+    return bool(user.volunteer_experience)
+
+
+def compute_missing_profile_fields(user: User, *, db: Optional[Session] = None) -> list[str]:
+    always_required = ["phone", "date_of_birth", "pronouns", "shirt_size", "dietary_restriction"]
+    missing = [f for f in always_required if not getattr(user, f)]
+
+    if not user.student_status:
+        missing.append("student_status")
+    elif user.student_status == "Non-Student":
+        if not user.employer:
+            missing.append("employer")
+    else:
+        for f in ["university", "major", "year_level", "graduation_year"]:
+            if not getattr(user, f):
+                missing.append(f)
+
+    if user.has_competition_experience is None:
+        missing.append("has_competition_experience")
+    elif user.has_competition_experience is True and not _has_competition_rows(user, db):
+        missing.append("has_competition_experience")
+
+    if user.has_volunteer_experience is None:
+        missing.append("has_volunteer_experience")
+    elif user.has_volunteer_experience is True and not _has_volunteer_rows(user, db):
+        missing.append("has_volunteer_experience")
+
+    return missing
+
+
+def is_profile_complete(user: User, *, db: Optional[Session] = None) -> bool:
+    return not compute_missing_profile_fields(user, db=db)

--- a/backend/app/core/users.py
+++ b/backend/app/core/users.py
@@ -1,11 +1,15 @@
 from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 from datetime import date
+from typing import Optional
 
 from app.models.models import User
 
-def check_if_email_exists(db: Session, email: str):
-    existing = db.query(User).filter(User.email == email.lower()).first()
+def check_if_email_exists(db: Session, email: str, exclude_user_id: Optional[int] = None):
+    query = db.query(User).filter(User.email == email.lower())
+    if exclude_user_id is not None:
+        query = query.filter(User.id != exclude_user_id)
+    existing = query.first()
     if existing:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/backend/app/core/users.py
+++ b/backend/app/core/users.py
@@ -1,5 +1,6 @@
 from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
+from datetime import date
 
 from app.models.models import User
 
@@ -17,3 +18,9 @@ def find_user_by_id(db: Session, id: int) -> User:
     if not user:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
     return user
+
+def calculate_age(birth_date: date, reference_date: date) -> int:
+    return reference_date.year - birth_date.year - ((reference_date.month, reference_date.day) < (birth_date.month, birth_date.day))
+
+def meets_age_requirement(birth_date: date, reference_date: date, min_age: int) -> bool:
+    return calculate_age(birth_date, reference_date) >= min_age

--- a/backend/app/core/users.py
+++ b/backend/app/core/users.py
@@ -18,9 +18,3 @@ def find_user_by_id(db: Session, id: int) -> User:
     if not user:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
     return user
-
-def calculate_age(birth_date: date, reference_date: date) -> int:
-    return reference_date.year - birth_date.year - ((reference_date.month, reference_date.day) < (birth_date.month, birth_date.day))
-
-def meets_age_requirement(birth_date: date, reference_date: date, min_age: int) -> bool:
-    return calculate_age(birth_date, reference_date) >= min_age

--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -33,7 +33,7 @@ def seed_dev_data(db: Session) -> None:
 
     Idempotent — skips if admin already exists.
     """
-    from app.models.models import Membership, Tournament, User
+    from app.models.models import TournamentMembership, Tournament, User
     from app.core.auth import hash_password
     from app.core.permissions import DEFAULT_POSITIONS
     from datetime import datetime
@@ -94,7 +94,7 @@ def seed_dev_data(db: Session) -> None:
     db.flush()  # get tournament.id before creating memberships
 
     # TD membership for the regular user — full manage_tournament access
-    td_membership = Membership(
+    td_membership = TournamentMembership(
         user_id=td.id,
         tournament_id=tournament.id,
         positions=["tournament_director"],
@@ -104,7 +104,7 @@ def seed_dev_data(db: Session) -> None:
 
     # Volunteer membership for admin — demonstrates cross-role scenario:
     # admin has site-wide access AND a volunteer-level membership here
-    admin_membership = Membership(
+    admin_membership = TournamentMembership(
         user_id=admin.id,
         tournament_id=tournament.id,
         positions=["event_supervisor"],

--- a/backend/app/db/seed_canon_events.py
+++ b/backend/app/db/seed_canon_events.py
@@ -1,0 +1,242 @@
+"""
+Idempotent seed for event categories and events.
+
+Safe to run in ANY environment (dev or prod) — uses ON CONFLICT DO NOTHING
+keyed on the unique `name` column, so it never duplicates or overwrites
+existing rows. Intended to be called every startup from the lifespan.
+
+Run directly:
+    python -m app.db.seed_events
+"""
+
+from sqlalchemy.orm import Session
+from sqlalchemy.dialects.postgresql import insert
+
+CATEGORIES = [
+    "Life, Personal & Social Science",
+    "Earth & Space Science",
+    "Physical Science & Chemistry",
+    "Technology & Engineering",
+    "Inquiry & Nature of Science",
+]
+
+# event name -> category name
+EVENTS = {
+    "A is for Anatomy": "Life, Personal & Social Science",
+    "Aerodynamics": "Technology & Engineering",
+    "Air Trajectory": "Technology & Engineering",
+    "Amphibians & Reptiles": "Life, Personal & Social Science",
+    "Anatomy": "Life, Personal & Social Science",
+    "Anatomy & Physiology": "Life, Personal & Social Science",
+    "Astronomy": "Earth & Space Science",
+    "Awesome Aquifers": "Earth & Space Science",
+    "Balancing Equations": "Physical Science & Chemistry",
+    "Balloon Launch Glider": "Technology & Engineering",
+    "Balloon Race": "Technology & Engineering",
+    "Battery Buggy": "Technology & Engineering",
+    "Bio-Process Lab": "Life, Personal & Social Science",
+    "Boomilever": "Technology & Engineering",
+    "Bottle Rocket": "Technology & Engineering",
+    "Bridge": "Technology & Engineering",
+    "Bridge Building": "Technology & Engineering",
+    "Bungee Drop": "Technology & Engineering",
+    "Bungee Egg Drop": "Technology & Engineering",
+    "Calorimeter": "Physical Science & Chemistry",
+    "Can't Judge a Powder": "Physical Science & Chemistry",
+    "Cell Biology": "Life, Personal & Social Science",
+    "Chemical ID": "Physical Science & Chemistry",
+    "Chemistry Clue": "Physical Science & Chemistry",
+    "Chemistry Lab": "Physical Science & Chemistry",
+    "Circuit Lab": "Physical Science & Chemistry",
+    "Codebusters": "Inquiry & Nature of Science",
+    "Compound Machines": "Technology & Engineering",
+    "Compute This": "Inquiry & Nature of Science",
+    "Computer Programming": "Technology & Engineering",
+    "Cow-A-Bungee": "Technology & Engineering",
+    "Crave the Wave": "Physical Science & Chemistry",
+    "Crime Busters": "Physical Science & Chemistry",
+    "Density Lab": "Physical Science & Chemistry",
+    "Designer Genes": "Life, Personal & Social Science",
+    "Detector Building": "Technology & Engineering",
+    "Disease Detectives": "Life, Personal & Social Science",
+    "Don't Bug Me": "Life, Personal & Social Science",
+    "Dynamic Planet": "Earth & Space Science",
+    "Earth Science Lab": "Earth & Space Science",
+    "Earth Science Processes": "Earth & Space Science",
+    "Earth, Sea, and Sky": "Earth & Space Science",
+    "Ecology": "Life, Personal & Social Science",
+    "Egg Drop": "Technology & Engineering",
+    "Egg-O-Naut": "Technology & Engineering",
+    "Elastic Launched Glider": "Technology & Engineering",
+    "Electric Vehicle": "Technology & Engineering",
+    "Electric Wright Stuff": "Technology & Engineering",
+    "Elevated Bridge": "Technology & Engineering",
+    "Energy Contest": "Physical Science & Chemistry",
+    "Engineering CAD": "Technology & Engineering",
+    "Entomology": "Life, Personal & Social Science",
+    "Environmental Chemistry": "Physical Science & Chemistry",
+    "Experimental Design": "Inquiry & Nature of Science",
+    "Facts in Five": "Inquiry & Nature of Science",
+    "Fast Facts": "Inquiry & Nature of Science",
+    "Feathered Frenzy": "Life, Personal & Social Science",
+    "Fermi Questions": "Inquiry & Nature of Science",
+    "Five Star Science": "Inquiry & Nature of Science",
+    "Flight": "Technology & Engineering",
+    "Food Science": "Physical Science & Chemistry",
+    "Forensics": "Physical Science & Chemistry",
+    "Forestry": "Life, Personal & Social Science",
+    "Fossils": "Earth & Space Science",
+    "From A Distance": "Earth & Space Science",
+    "Game On": "Technology & Engineering",
+    "Geologic Mapping": "Earth & Space Science",
+    "Get Your Bearing": "Earth & Space Science",
+    "Gravity Vehicle": "Technology & Engineering",
+    "Green Generation": "Life, Personal & Social Science",
+    "Health Science": "Life, Personal & Social Science",
+    "Helicopter": "Technology & Engineering",
+    "Helicopters": "Technology & Engineering",
+    "Heredity": "Life, Personal & Social Science",
+    "Herpetology": "Life, Personal & Social Science",
+    "Hot House": "Earth & Space Science",
+    "Hovercraft": "Technology & Engineering",
+    "Hydrogeology": "Earth & Space Science",
+    "Invasive Species": "Life, Personal & Social Science",
+    "It's About Time": "Technology & Engineering",
+    "Junkyard Challenge": "Technology & Engineering",
+    "Keep the Heat": "Physical Science & Chemistry",
+    "Kite Flying": "Technology & Engineering",
+    "Laser Shoot": "Physical Science & Chemistry",
+    "Life Science Process Lab": "Life, Personal & Social Science",
+    "Machines": "Technology & Engineering",
+    "MagLev": "Technology & Engineering",
+    "Map Reading": "Earth & Space Science",
+    "Materials Science": "Physical Science & Chemistry",
+    "Measurement": "Inquiry & Nature of Science",
+    "Meteorology": "Earth & Space Science",
+    "Metric Estimation": "Inquiry & Nature of Science",
+    "Metric Mastery": "Inquiry & Nature of Science",
+    "Microbe Mission": "Life, Personal & Social Science",
+    "Mission Possible": "Technology & Engineering",
+    "Mousetrap Vehicle": "Technology & Engineering",
+    "Mystery Architecture": "Technology & Engineering",
+    "Mystery Substance": "Physical Science & Chemistry",
+    "Naked Egg Drop": "Technology & Engineering",
+    "Name That Artifact": "Life, Personal & Social Science",
+    "Name That Organism": "Life, Personal & Social Science",
+    "Nature Quest": "Life, Personal & Social Science",
+    "Oceanography": "Earth & Space Science",
+    "Optics": "Physical Science & Chemistry",
+    "Orienteering": "Earth & Space Science",
+    "Ornithology": "Life, Personal & Social Science",
+    "Out of This World": "Earth & Space Science",
+    "Paper Airplane": "Technology & Engineering",
+    "Password": "Inquiry & Nature of Science",
+    "Pentathlon": "Inquiry & Nature of Science",
+    "Periodic Table Quiz": "Physical Science & Chemistry",
+    "Physical Science Lab": "Physical Science & Chemistry",
+    "Physics Lab": "Physical Science & Chemistry",
+    "Picture This": "Inquiry & Nature of Science",
+    "Ping-Pong Parachute": "Technology & Engineering",
+    "Polymer Detective": "Physical Science & Chemistry",
+    "Potions and Poisons": "Physical Science & Chemistry",
+    "Practical Data Gathering": "Inquiry & Nature of Science",
+    "Practical Data Solving": "Inquiry & Nature of Science",
+    "Process Skills": "Inquiry & Nature of Science",
+    "Process Skills in Life Science": "Life, Personal & Social Science",
+    "Propeller Propulsion": "Technology & Engineering",
+    "Protein Modeling": "Life, Personal & Social Science",
+    "Qualitative Analysis": "Physical Science & Chemistry",
+    "Reach for the Stars": "Earth & Space Science",
+    "Redesigned Genes": "Life, Personal & Social Science",
+    "Remote Sensing": "Earth & Space Science",
+    "Road Rally": "Technology & Engineering",
+    "Road Scholar": "Earth & Space Science",
+    "Robo-Billiards": "Technology & Engineering",
+    "Robo-Cross": "Technology & Engineering",
+    "Robot Arm": "Technology & Engineering",
+    "Robot Ramble": "Technology & Engineering",
+    "Robot Tour": "Technology & Engineering",
+    "Rocks and Fossils": "Earth & Space Science",
+    "Rocks and Minerals": "Earth & Space Science",
+    "Rocks to Riches": "Earth & Space Science",
+    "Rocks, Minerals, and Fossils": "Earth & Space Science",
+    "Roller Coaster": "Physical Science & Chemistry",
+    "Rotor Egg Drop": "Technology & Engineering",
+    "Rube Goldberg Machine": "Technology & Engineering",
+    "Science Bowl": "Inquiry & Nature of Science",
+    "Science Clue": "Inquiry & Nature of Science",
+    "Science Crime Busters": "Physical Science & Chemistry",
+    "Science of Fitness": "Life, Personal & Social Science",
+    "Science Search": "Inquiry & Nature of Science",
+    "Science Word": "Inquiry & Nature of Science",
+    "Scrambler": "Technology & Engineering",
+    "Seven Up": "Inquiry & Nature of Science",
+    "Shock Value": "Physical Science & Chemistry",
+    "Simple Machines": "Technology & Engineering",
+    "Solar Collector": "Technology & Engineering",
+    "Solar Heating Contest": "Technology & Engineering",
+    "Solar System": "Earth & Space Science",
+    "Sounds of Music": "Physical Science & Chemistry",
+    "Storm the Castle": "Technology & Engineering",
+    "Sumo Bots": "Technology & Engineering",
+    "Surfing the Net": "Inquiry & Nature of Science",
+    "Technical Problem Solving": "Inquiry & Nature of Science",
+    "Thermodynamics": "Physical Science & Chemistry",
+    "Tic Toc": "Technology & Engineering",
+    "Titration Race": "Physical Science & Chemistry",
+    "Topographic Map Reading": "Earth & Space Science",
+    "Tower": "Technology & Engineering",
+    "Trajectory": "Technology & Engineering",
+    "Trajectory Contest": "Technology & Engineering",
+    "Tree Identification": "Life, Personal & Social Science",
+    "Tree-mendous": "Life, Personal & Social Science",
+    "Up, Up, & Away": "Technology & Engineering",
+    "Using the Web": "Inquiry & Nature of Science",
+    "Water Quality": "Earth & Space Science",
+    "Water Strider": "Technology & Engineering",
+    "Water, Water Everywhere": "Earth & Space Science",
+    "Weather Or Not": "Earth & Space Science",
+    "What Are You Trying To Tell Me": "Inquiry & Nature of Science",
+    "Wheeled Vehicle": "Technology & Engineering",
+    "WiFi Lab": "Technology & Engineering",
+    "Wind Power": "Technology & Engineering",
+    "Wright Stuff": "Technology & Engineering",
+    "Write It Do It": "Inquiry & Nature of Science",
+}
+
+
+def seed_events_and_categories(db: Session) -> None:
+    """
+    Upsert categories + events by unique `name`. Safe to call on every
+    startup in every environment — existing rows are left untouched.
+    """
+    from app.models.models import EventCategory, Event
+
+    # 1. Categories
+    stmt = insert(EventCategory).values([{"name": name} for name in CATEGORIES])
+    stmt = stmt.on_conflict_do_nothing(index_elements=["name"])
+    db.execute(stmt)
+    db.commit()
+
+    # 2. Look up category ids by name (works whether just-inserted or pre-existing)
+    category_rows = db.query(EventCategory.id, EventCategory.name).all()
+    category_id_by_name = {name: cid for cid, name in category_rows}
+
+    # 3. Events
+    event_values = [
+        {"name": event_name, "category_id": category_id_by_name[category_name]}
+        for event_name, category_name in EVENTS.items()
+    ]
+    stmt = insert(Event).values(event_values)
+    stmt = stmt.on_conflict_do_nothing(index_elements=["name"])
+    db.execute(stmt)
+    db.commit()
+
+    print(f"✓ Seeded/verified {len(CATEGORIES)} categories and {len(EVENTS)} events.")
+
+
+if __name__ == "__main__":
+    from app.db.session import SessionLocal
+
+    with SessionLocal() as db:
+        seed_events_and_categories(db)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,9 +19,14 @@ settings = get_settings()
 async def lifespan(app: FastAPI):
     import os
     if os.environ.get("PYTEST_CURRENT_TEST") is None:
+        from app.db.session import SessionLocal
+        from app.db.seed_canon_events import seed_events_and_categories
+
+        with SessionLocal() as db:
+            seed_events_and_categories(db)  # always — dev + prod
+
         if get_settings().app_env in ("development", "preview"):
             init_db()
-            from app.db.session import SessionLocal
             with SessionLocal() as db:
                 seed_dev_data(db)
     yield

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,7 @@ from app.db.init_db import init_db, seed_dev_data
 from app.api.routes import (
     auth, events, tournaments,
     tournament_events, tournament_memberships,
-    sheets, users
+    sheets, users, user_experience
 )
 
 settings = get_settings()
@@ -59,6 +59,7 @@ app.include_router(tournament_events.router,      prefix="", dependencies=[api_k
 app.include_router(tournament_memberships.router, prefix="", dependencies=[api_key_dependency])
 app.include_router(sheets.router,                 prefix="", dependencies=[api_key_dependency])
 app.include_router(users.router,                  prefix="", dependencies=[api_key_dependency])
+app.include_router(user_experience.router,        prefix="", dependencies=[api_key_dependency])
 
 
 @app.get("/health", tags=["meta"])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,9 +6,11 @@ from scalar_fastapi import get_scalar_api_reference
 from app.core.config import get_settings
 from app.core.security import verify_api_key
 from app.db.init_db import init_db, seed_dev_data
-from app.api.routes import tournaments, sheets, events, users
-from app.api.routes import auth
-from backend.app.api.routes import tournament_memberships
+from app.api.routes import (
+    auth, events, tournaments,
+    tournament_events, tournament_memberships,
+    sheets, users
+)
 
 settings = get_settings()
 
@@ -50,12 +52,13 @@ api_key_dependency = Depends(verify_api_key)
 
 # All routes require API key — including auth (login, logout, register).
 # In development with API_KEY unset, security.py skips the check automatically.
-app.include_router(auth.router,        prefix="", dependencies=[api_key_dependency])
-app.include_router(tournaments.router, prefix="", dependencies=[api_key_dependency])
-app.include_router(events.router,      prefix="", dependencies=[api_key_dependency])
+app.include_router(auth.router,                   prefix="", dependencies=[api_key_dependency])
+app.include_router(events.router,                 prefix="", dependencies=[api_key_dependency])
+app.include_router(tournaments.router,            prefix="", dependencies=[api_key_dependency])
+app.include_router(tournament_events.router,      prefix="", dependencies=[api_key_dependency])
 app.include_router(tournament_memberships.router, prefix="", dependencies=[api_key_dependency])
-app.include_router(sheets.router,      prefix="", dependencies=[api_key_dependency])
-app.include_router(users.router,       prefix="", dependencies=[api_key_dependency])
+app.include_router(sheets.router,                 prefix="", dependencies=[api_key_dependency])
+app.include_router(users.router,                  prefix="", dependencies=[api_key_dependency])
 
 
 @app.get("/health", tags=["meta"])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,8 +6,9 @@ from scalar_fastapi import get_scalar_api_reference
 from app.core.config import get_settings
 from app.core.security import verify_api_key
 from app.db.init_db import init_db, seed_dev_data
-from app.api.routes import tournaments, sheets, events, users, memberships
+from app.api.routes import tournaments, sheets, events, users
 from app.api.routes import auth
+from backend.app.api.routes import tournament_memberships
 
 settings = get_settings()
 
@@ -52,7 +53,7 @@ api_key_dependency = Depends(verify_api_key)
 app.include_router(auth.router,        prefix="", dependencies=[api_key_dependency])
 app.include_router(tournaments.router, prefix="", dependencies=[api_key_dependency])
 app.include_router(events.router,      prefix="", dependencies=[api_key_dependency])
-app.include_router(memberships.router, prefix="", dependencies=[api_key_dependency])
+app.include_router(tournament_memberships.router, prefix="", dependencies=[api_key_dependency])
 app.include_router(sheets.router,      prefix="", dependencies=[api_key_dependency])
 app.include_router(users.router,       prefix="", dependencies=[api_key_dependency])
 

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import relationship
 from typing import Optional
 
 from app.db.session import Base
-from app.core.users import calculate_age, meets_age_requirement
+from app.core.age import meets_age_requirement
 
 
 def utcnow():

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -83,6 +83,12 @@ class User(Base):
         foreign_keys="UserCompetitionExperience.user_id",
         cascade="all, delete-orphan"
     )
+    volunteer_experience = relationship(
+        "UserVolunteerExperience",
+        back_populates="user",
+        foreign_keys="UserVolunteerExperience.user_id",
+        cascade="all, delete-orphan"
+    )
 
 # ---------------------------------------------------------------------------
 # Competition Experience
@@ -100,6 +106,42 @@ class UserCompetitionExperience(Base):
     event = relationship("Event", back_populates="user_competition_experience")
 
 
+
+# ---------------------------------------------------------------------------
+# Volunteer Experience
+# ---------------------------------------------------------------------------
+class UserVolunteerExperience(Base):
+    __tablename__ = "user_volunteer_experience"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete="CASCADE"), nullable=False)
+    
+    # manual add by the user
+    tournament_name = Column(String(255), nullable=True)
+    year = Column(Integer, nullable=True)
+    event_id = Column(Integer, ForeignKey('events.id', ondelete="RESTRICT"), nullable=True)
+    role = Column(String(63), nullable=True)
+
+    # NEXUS tournament
+    tournament_id = Column(Integer, ForeignKey('tournaments.id', ondelete="CASCADE"), nullable=True)
+    
+    # keys: "event", "other"
+    #   - "event" only on manual add, for custom event names (doesn't exist in cannonical list)
+    #   - "other" extra notes from user on their experience (both routes: manual and NEXUS)
+    notes = Column(JSON, nullable=True)
+    
+    # locked state locks everything except notes
+    is_locked = Column(Boolean, default=False, nullable=False)
+
+    # NEXUS -- tournament_id only
+    # manual -- tournament_name, year, role, event_id or notes["events"] (for custom event names)
+    # NOTE: possible bugs since the NEXUS vs. manual constraint isn't enforced at the raw SQL level
+
+    user = relationship("User", back_populates="volunteer_experience")
+    tournament = relationship("Tournament", back_populates="user_volunteer_experience")
+    event = relationship("Event", back_populates="user_volunteer_experience")
+
+    
 
 # ---------------------------------------------------------------------------
 # Event Category
@@ -127,6 +169,11 @@ class Event(Base):
         "UserCompetitionExperience",
         back_populates="event",
         foreign_keys="UserCompetitionExperience.event_id"
+    )
+    user_volunteer_experience = relationship(
+        "UserVolunteerExperience",
+        back_populates="event",
+        foreign_keys="UserVolunteerExperience.event_id"
     )
 
 
@@ -169,6 +216,12 @@ class Tournament(Base):
     )
     memberships = relationship(
         "TournamentMembership", back_populates="tournament", cascade="all, delete-orphan"
+    )
+    user_volunteer_experience = relationship(
+        "UserVolunteerExperience",
+        back_populates="tournament",
+        foreign_keys="UserVolunteerExperience.tournament_id",
+        cascade="all, delete-orphan"
     )
 
 # ---------------------------------------------------------------------------

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -3,10 +3,6 @@ SQLAlchemy ORM models.
 
 NOTE: Using classic Column style (not Mapped[] annotations) for compatibility
 with SQLAlchemy 2.0.36 + Python 3.13.
-
-STATUS LEGEND:
-  [ACTIVE] — built and in use
-  [FUTURE] — planned, not yet implemented
 """
 
 from datetime import datetime, timezone
@@ -24,49 +20,7 @@ def utcnow():
 
 
 # ---------------------------------------------------------------------------
-# [ACTIVE] Tournament
-# ---------------------------------------------------------------------------
-class Tournament(Base):
-    __tablename__ = "tournaments"
-
-    id = Column(Integer, primary_key=True, index=True)
-    name = Column(String(255), nullable=False)
-    start_date = Column(DateTime(timezone=True), nullable=True)
-    end_date = Column(DateTime(timezone=True), nullable=True)
-    location = Column(String(255), nullable=True)
-
-    # [{number, label, date, start, end}, ...]
-    blocks = Column(JSON, nullable=False, default=list)
-
-    # {
-    #   custom_fields: [{key, label, type}, ...],
-    #   positions: [{key, label, permissions: [...]}, ...]
-    # }
-    # Positions are auto-populated from DEFAULT_POSITIONS on tournament create.
-    # TDs can customise per-tournament at any time.
-    volunteer_schema = Column(JSON, nullable=False, default=dict)
-
-    # The user who created this tournament.
-    # Always has a membership with positions=["tournament_director"].
-    owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)
-
-    created_at = Column(DateTime(timezone=True), default=utcnow)
-    updated_at = Column(DateTime(timezone=True), default=utcnow, onupdate=utcnow)
-
-    owner = relationship("User", back_populates="tournaments", foreign_keys=[owner_id])
-    sheet_configs = relationship(
-        "SheetConfig", back_populates="tournament", cascade="all, delete-orphan"
-    )
-    events = relationship(
-        "Event", back_populates="tournament", cascade="all, delete-orphan"
-    )
-    memberships = relationship(
-        "Membership", back_populates="tournament", cascade="all, delete-orphan"
-    )
-
-
-# ---------------------------------------------------------------------------
-# [ACTIVE] User
+# User
 # Core identity — volunteers, TDs, and admins all live here.
 #
 # role = "admin" | "user"
@@ -118,15 +72,79 @@ class User(Base):
     updated_at = Column(DateTime(timezone=True), default=utcnow, onupdate=utcnow)
 
     memberships = relationship(
-        "Membership", back_populates="user", cascade="all, delete-orphan"
+        "TournamentMembership", back_populates="user", cascade="all, delete-orphan"
     )
     tournaments = relationship(
         "Tournament", back_populates="owner", foreign_keys="Tournament.owner_id"
     )
 
+# ---------------------------------------------------------------------------
+# Event Category
+# ---------------------------------------------------------------------------
+class EventCategory(Base):
+    __tablename__ = "event_categories"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(255), nullable=False)
+
+    events = relationship("Event", back_populates="category", cascade="all, delete-orphan")
 
 # ---------------------------------------------------------------------------
-# [ACTIVE] Membership
+# Event
+# ---------------------------------------------------------------------------
+class Event(Base):
+    __tablename__ = "events"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(255), nullable=False)
+    category_id = Column(Integer, ForeignKey('event_categories.id'), nullable=False)
+
+    category = relationship("EventCategory", back_populates="events")
+
+
+# ---------------------------------------------------------------------------
+# Tournament
+# ---------------------------------------------------------------------------
+class Tournament(Base):
+    __tablename__ = "tournaments"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(255), nullable=False)
+    start_date = Column(DateTime(timezone=True), nullable=True)
+    end_date = Column(DateTime(timezone=True), nullable=True)
+    location = Column(String(255), nullable=True)
+
+    # [{number, label, date, start, end}, ...]
+    blocks = Column(JSON, nullable=False, default=list)
+
+    # {
+    #   custom_fields: [{key, label, type}, ...],
+    #   positions: [{key, label, permissions: [...]}, ...]
+    # }
+    # Positions are auto-populated from DEFAULT_POSITIONS on tournament create.
+    # TDs can customise per-tournament at any time.
+    volunteer_schema = Column(JSON, nullable=False, default=dict)
+
+    # The user who created this tournament.
+    # Always has a membership with positions=["tournament_director"].
+    owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+
+    created_at = Column(DateTime(timezone=True), default=utcnow)
+    updated_at = Column(DateTime(timezone=True), default=utcnow, onupdate=utcnow)
+
+    owner = relationship("User", back_populates="tournaments", foreign_keys=[owner_id])
+    sheet_configs = relationship(
+        "SheetConfig", back_populates="tournament", cascade="all, delete-orphan"
+    )
+    events = relationship(
+        "TournamentEvent", back_populates="tournament", cascade="all, delete-orphan"
+    )
+    memberships = relationship(
+        "Membership", back_populates="tournament", cascade="all, delete-orphan"
+    )
+
+# ---------------------------------------------------------------------------
+# Tournament Membership
 # Links a User to a Tournament — their full volunteer record for that event.
 #
 # positions: list of position keys (e.g. ["tournament_director", "test_writer"])
@@ -144,8 +162,8 @@ class User(Base):
 # are defined per-tournament in Tournament.volunteer_schema["custom_fields"], making
 # the system flexible for any tournament's arbitrary form data.
 # ---------------------------------------------------------------------------
-class Membership(Base):
-    __tablename__ = "memberships"
+class TournamentMembership(Base):
+    __tablename__ = "tournament_memberships"
 
     id = Column(Integer, primary_key=True, index=True)
     user_id = Column(
@@ -155,7 +173,7 @@ class Membership(Base):
         Integer, ForeignKey("tournaments.id", ondelete="CASCADE"), nullable=False
     )
     assigned_event_id = Column(
-        Integer, ForeignKey("events.id", ondelete="SET NULL"), nullable=True
+        Integer, ForeignKey("tournament_events.id", ondelete="SET NULL"), nullable=True
     )
 
     # Title(s) + permission level within this tournament.
@@ -201,7 +219,7 @@ class Membership(Base):
     # Relationships
     user = relationship("User", back_populates="memberships")
     tournament = relationship("Tournament", back_populates="memberships")
-    assigned_event = relationship("Event", back_populates="memberships")
+    assigned_event = relationship("TournamentEvent", back_populates="memberships")
 
     __table_args__ = (
         # One membership per user per tournament
@@ -220,7 +238,7 @@ class Membership(Base):
 
 
 # ---------------------------------------------------------------------------
-# [ACTIVE] SheetConfig
+# SheetConfig
 # ---------------------------------------------------------------------------
 class SheetConfig(Base):
     __tablename__ = "sheet_configs"
@@ -244,29 +262,34 @@ class SheetConfig(Base):
 
 
 # ---------------------------------------------------------------------------
-# [ACTIVE] Event
+# Tournament Event
 # ---------------------------------------------------------------------------
-class Event(Base):
-    __tablename__ = "events"
+class TournamentEvent(Base):
+    __tablename__ = "tournament_events"
 
     id = Column(Integer, primary_key=True, index=True)
     tournament_id = Column(
         Integer, ForeignKey("tournaments.id", ondelete="CASCADE"), nullable=False
     )
+    
     name = Column(String(255), nullable=False)
     division = Column(String(4), nullable=False)           # "B" | "C"
     event_type = Column(String(32), nullable=False, default="standard")  # "standard" | "trial"
     category = Column(String(255), nullable=True)
+    
     building = Column(String(255), nullable=True)
     room = Column(String(64), nullable=True)
     floor = Column(String(64), nullable=True)
+    
     volunteers_needed = Column(Integer, nullable=False, default=2)
+    
     blocks = Column(JSON, nullable=False, default=list)    # [1,2,3,4,5,6]
+    
     created_at = Column(DateTime(timezone=True), default=utcnow)
     updated_at = Column(DateTime(timezone=True), default=utcnow, onupdate=utcnow)
 
     tournament = relationship("Tournament", back_populates="events")
-    memberships = relationship("Membership", back_populates="assigned_event")
+    memberships = relationship("TournamentMembership", back_populates="assigned_event")
 
     __table_args__ = (
         UniqueConstraint("tournament_id", "name", "division", name="uq_tournament_event_division"),

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -315,16 +315,6 @@ class TournamentMembership(Base):
         UniqueConstraint("user_id", "tournament_id", name="uq_user_tournament"),
     )
 
-    # TODO(temp): remove when user account self-management is implemented
-    shirt_size           = Column(String(16),  nullable=True)
-    dietary_restriction  = Column(String(255), nullable=True)
-    university           = Column(String(255), nullable=True)
-    major                = Column(String(255), nullable=True)
-    employer             = Column(String(255), nullable=True)
-    student_status       = Column(String(100), nullable=True)
-    competition_exp      = Column(Text,        nullable=True)
-    volunteering_exp     = Column(Text,        nullable=True)
-
 
 # ---------------------------------------------------------------------------
 # SheetConfig

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -109,6 +109,8 @@ class UserCompetitionExperience(Base):
 
 # ---------------------------------------------------------------------------
 # Volunteer Experience
+# 
+# NOTE: manual entry only, auto-populate NEXUS tournament history onto user's profile
 # ---------------------------------------------------------------------------
 class UserVolunteerExperience(Base):
     __tablename__ = "user_volunteer_experience"
@@ -117,28 +119,17 @@ class UserVolunteerExperience(Base):
     user_id = Column(Integer, ForeignKey('users.id', ondelete="CASCADE"), nullable=False)
     
     # manual add by the user
-    tournament_name = Column(String(255), nullable=True)
-    year = Column(Integer, nullable=True)
+    tournament_name = Column(String(255), nullable=False)
+    year = Column(Integer, nullable=False)
     event_id = Column(Integer, ForeignKey('events.id', ondelete="RESTRICT"), nullable=True)
-    role = Column(String(63), nullable=True)
-
-    # NEXUS tournament
-    tournament_id = Column(Integer, ForeignKey('tournaments.id', ondelete="CASCADE"), nullable=True)
+    role = Column(String(63), nullable=False)
     
     # keys: "event", "other"
     #   - "event" only on manual add, for custom event names (doesn't exist in cannonical list)
-    #   - "other" extra notes from user on their experience (both routes: manual and NEXUS)
+    #   - "other" extra notes from user on their experience
     notes = Column(JSON, nullable=True)
-    
-    # locked state locks everything except notes
-    is_locked = Column(Boolean, default=False, nullable=False)
-
-    # NEXUS -- tournament_id only
-    # manual -- tournament_name, year, role, event_id or notes["events"] (for custom event names)
-    # NOTE: possible bugs since the NEXUS vs. manual constraint isn't enforced at the raw SQL level
 
     user = relationship("User", back_populates="volunteer_experience")
-    tournament = relationship("Tournament", back_populates="user_volunteer_experience")
     event = relationship("Event", back_populates="user_volunteer_experience")
 
     
@@ -216,12 +207,6 @@ class Tournament(Base):
     )
     memberships = relationship(
         "TournamentMembership", back_populates="tournament", cascade="all, delete-orphan"
-    )
-    user_volunteer_experience = relationship(
-        "UserVolunteerExperience",
-        back_populates="tournament",
-        foreign_keys="UserVolunteerExperience.tournament_id",
-        cascade="all, delete-orphan"
     )
 
 # ---------------------------------------------------------------------------

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -163,12 +163,14 @@ class Event(Base):
     user_competition_experience = relationship(
         "UserCompetitionExperience",
         back_populates="event",
-        foreign_keys="UserCompetitionExperience.event_id"
+        foreign_keys="UserCompetitionExperience.event_id",
+        passive_deletes=True,
     )
     user_volunteer_experience = relationship(
         "UserVolunteerExperience",
         back_populates="event",
-        foreign_keys="UserVolunteerExperience.event_id"
+        foreign_keys="UserVolunteerExperience.event_id",
+        passive_deletes=True,
     )
 
 

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -11,7 +11,7 @@ STATUS LEGEND:
 
 from datetime import datetime, timezone
 from sqlalchemy import (
-    Integer, String, Text, Boolean, DateTime, JSON,
+    Integer, String, Text, Boolean, Date, DateTime, JSON,
     ForeignKey, UniqueConstraint, Column,
 )
 from sqlalchemy.orm import relationship
@@ -88,6 +88,8 @@ class User(Base):
     last_name = Column(String(100), nullable=False)
     email = Column(String(255), unique=True, index=True, nullable=False)
     phone = Column(String(32), nullable=True)
+    date_of_birth = Column(Date, nullable=True)
+    pronouns = Column(String(100), nullable=True)
 
     # Auth fields
     hashed_password = Column(String(255), nullable=True)   # null = cannot log in, must reset password and verify via email
@@ -105,8 +107,9 @@ class User(Base):
     # if not a student
     employer = Column(String(255), nullable=True)
     
-    competition_exp = Column(Text, nullable=True)             # free-form competition experience
-    volunteering_exp = Column(Text, nullable=True)            # free-form volunteering experience
+    has_competition_experience = Column(Boolean, nullable=True)
+    has_volunteer_experience = Column(Boolean, nullable=True)
+    # has_stem_experience = Column(Boolean, nullable=True)        # debatable
 
     shirt_size = Column(String(16), nullable=True)
     dietary_restriction = Column(String(255), nullable=True)

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -77,6 +77,29 @@ class User(Base):
     tournaments = relationship(
         "Tournament", back_populates="owner", foreign_keys="Tournament.owner_id"
     )
+    competition_experience = relationship(
+        "UserCompetitionExperience",
+        back_populates="user",
+        foreign_keys="UserCompetitionExperience.user_id",
+        cascade="all, delete-orphan"
+    )
+
+# ---------------------------------------------------------------------------
+# Competition Experience
+# ---------------------------------------------------------------------------
+class UserCompetitionExperience(Base):
+    __tablename__ = "user_competition_experience"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey('users.id', ondelete="CASCADE"), nullable=False)
+    event_id = Column(Integer, ForeignKey('events.id', ondelete="RESTRICT"), nullable=False)
+    school = Column(String(255), nullable=False)
+    notes = Column(Text, nullable=True)
+
+    user = relationship("User", back_populates="competition_experience")
+    event = relationship("Event", back_populates="user_competition_experience")
+
+
 
 # ---------------------------------------------------------------------------
 # Event Category
@@ -100,6 +123,11 @@ class Event(Base):
     category_id = Column(Integer, ForeignKey('event_categories.id'), nullable=False)
 
     category = relationship("EventCategory", back_populates="events")
+    user_competition_experience = relationship(
+        "UserCompetitionExperience",
+        back_populates="event",
+        foreign_keys="UserCompetitionExperience.event_id"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -140,7 +168,7 @@ class Tournament(Base):
         "TournamentEvent", back_populates="tournament", cascade="all, delete-orphan"
     )
     memberships = relationship(
-        "Membership", back_populates="tournament", cascade="all, delete-orphan"
+        "TournamentMembership", back_populates="tournament", cascade="all, delete-orphan"
     )
 
 # ---------------------------------------------------------------------------

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -10,8 +10,12 @@ from sqlalchemy import (
     Integer, String, Text, Boolean, Date, DateTime, JSON,
     ForeignKey, UniqueConstraint, Column,
 )
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
+from typing import Optional
+
 from app.db.session import Base
+from app.core.users import calculate_age, meets_age_requirement
 
 
 def utcnow():
@@ -286,6 +290,25 @@ class TournamentMembership(Base):
     user = relationship("User", back_populates="memberships")
     tournament = relationship("Tournament", back_populates="memberships")
     assigned_event = relationship("TournamentEvent", back_populates="memberships")
+
+    @hybrid_property
+    def is_over_18(self) -> Optional[bool]:
+        if self.user.date_of_birth is None:
+            return None
+        
+        return meets_age_requirement(self.user.date_of_birth, self.tournament.start_date.date(), 18)
+    
+    @hybrid_property
+    def is_over_21(self) -> Optional[bool]:
+        if self.user.date_of_birth is None:
+            return None
+        
+        return meets_age_requirement(self.user.date_of_birth, self.tournament.start_date.date(), 21)
+    
+    # TODO: Add @is_over_18.expression / @is_over_21.expression using date-arithmetic
+    # (dob + interval '18 years' <= tournament.start_date) so tournament directors can
+    # filter registrations server-side instead of client-side. Needed once dashboard
+    # moves age filtering to backend / registration lists get large enough to paginate.
 
     __table_args__ = (
         # One membership per user per tournament

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -145,7 +145,7 @@ class EventCategory(Base):
     __tablename__ = "event_categories"
 
     id = Column(Integer, primary_key=True, index=True)
-    name = Column(String(255), nullable=False)
+    name = Column(String(255), unique=True, nullable=False)
 
     events = relationship("Event", back_populates="category", cascade="all, delete-orphan")
 
@@ -156,7 +156,7 @@ class Event(Base):
     __tablename__ = "events"
 
     id = Column(Integer, primary_key=True, index=True)
-    name = Column(String(255), nullable=False)
+    name = Column(String(255), unique=True, nullable=False)
     category_id = Column(Integer, ForeignKey('event_categories.id'), nullable=False)
 
     category = relationship("EventCategory", back_populates="events")

--- a/backend/app/schemas/event.py
+++ b/backend/app/schemas/event.py
@@ -1,76 +1,36 @@
 from __future__ import annotations
-from datetime import datetime
-from pydantic import BaseModel, field_validator
-
-VALID_DIVISIONS = {"B", "C"}
-VALID_EVENT_TYPES = {"standard", "trial"}
+from typing import Optional
+from pydantic import BaseModel
 
 
-class EventBase(BaseModel):
+class EventCategoryResponse(BaseModel):
+    id: int
     name: str
-    division: str
-    event_type: str = "standard"
-    category: str | None = None
-    building: str | None = None
-    room: str | None = None
-    floor: str | None = None
-    volunteers_needed: int = 2
-    # Block numbers this event runs e.g. [1,2,3,4,5,6]
-    # Empty list means the TD hasn't configured blocks yet
-    blocks: list[int] = []
 
-    @field_validator("division")
-    @classmethod
-    def validate_division(cls, v: str) -> str:
-        if v not in VALID_DIVISIONS:
-            raise ValueError(f"division must be one of: {VALID_DIVISIONS}")
-        return v
-
-    @field_validator("event_type")
-    @classmethod
-    def validate_event_type(cls, v: str) -> str:
-        if v not in VALID_EVENT_TYPES:
-            raise ValueError(f"event_type must be one of: {VALID_EVENT_TYPES}")
-        return v
-
-    @field_validator("volunteers_needed")
-    @classmethod
-    def validate_volunteers_needed(cls, v: int) -> int:
-        if v < 1:
-            raise ValueError("volunteers_needed must be at least 1")
-        return v
-
-    @field_validator("blocks")
-    @classmethod
-    def validate_blocks(cls, v: list[int]) -> list[int]:
-        if len(v) != len(set(v)):
-            raise ValueError("Block numbers must be unique")
-        if any(b < 1 for b in v):
-            raise ValueError("Block numbers must be positive integers")
-        return sorted(v)
+    model_config = {"from_attributes": True}
 
 
-class EventCreate(EventBase):
-    tournament_id: int
+class EventCategoryCreate(BaseModel):
+    name: str
+
+
+class EventCategoryUpdate(BaseModel):
+    name: str
+
+
+class EventResponse(BaseModel):
+    id: int
+    name: str
+    category_id: int
+
+    model_config = {"from_attributes": True}
+
+
+class EventCreate(BaseModel):
+    name: str
+    category_id: int
 
 
 class EventUpdate(BaseModel):
-    """Partial update — all fields optional."""
-    name: str | None = None
-    division: str | None = None
-    event_type: str | None = None
-    category: str | None = None
-    building: str | None = None
-    room: str | None = None
-    floor: str | None = None
-    volunteers_needed: int | None = None
-    blocks: list[int] | None = None
-
-
-class EventRead(EventBase):
-    id: int
-    tournament_id: int
-    created_at: datetime
-    updated_at: datetime
-
-    model_config = {"from_attributes": True}
+    name: Optional[str] = None
+    category_id: Optional[int] = None

--- a/backend/app/schemas/tournament_event.py
+++ b/backend/app/schemas/tournament_event.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+from datetime import datetime
+from pydantic import BaseModel, field_validator
+
+VALID_DIVISIONS = {"B", "C"}
+VALID_EVENT_TYPES = {"standard", "trial"}
+
+
+class EventBase(BaseModel):
+    name: str
+    division: str
+    event_type: str = "standard"
+    category: str | None = None
+    building: str | None = None
+    room: str | None = None
+    floor: str | None = None
+    volunteers_needed: int = 2
+    # Block numbers this event runs e.g. [1,2,3,4,5,6]
+    # Empty list means the TD hasn't configured blocks yet
+    blocks: list[int] = []
+
+    @field_validator("division")
+    @classmethod
+    def validate_division(cls, v: str) -> str:
+        if v not in VALID_DIVISIONS:
+            raise ValueError(f"division must be one of: {VALID_DIVISIONS}")
+        return v
+
+    @field_validator("event_type")
+    @classmethod
+    def validate_event_type(cls, v: str) -> str:
+        if v not in VALID_EVENT_TYPES:
+            raise ValueError(f"event_type must be one of: {VALID_EVENT_TYPES}")
+        return v
+
+    @field_validator("volunteers_needed")
+    @classmethod
+    def validate_volunteers_needed(cls, v: int) -> int:
+        if v < 1:
+            raise ValueError("volunteers_needed must be at least 1")
+        return v
+
+    @field_validator("blocks")
+    @classmethod
+    def validate_blocks(cls, v: list[int]) -> list[int]:
+        if len(v) != len(set(v)):
+            raise ValueError("Block numbers must be unique")
+        if any(b < 1 for b in v):
+            raise ValueError("Block numbers must be positive integers")
+        return sorted(v)
+
+
+class EventCreate(EventBase):
+    tournament_id: int
+
+
+class EventUpdate(BaseModel):
+    """Partial update — all fields optional."""
+    name: str | None = None
+    division: str | None = None
+    event_type: str | None = None
+    category: str | None = None
+    building: str | None = None
+    room: str | None = None
+    floor: str | None = None
+    volunteers_needed: int | None = None
+    blocks: list[int] | None = None
+
+
+class EventRead(EventBase):
+    id: int
+    tournament_id: int
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/backend/app/schemas/tournament_membership.py
+++ b/backend/app/schemas/tournament_membership.py
@@ -54,16 +54,6 @@ class MembershipBase(BaseModel):
     # Keys match custom_field.key in the tournament's volunteer_schema.
     extra_data: dict | None = None
 
-    # TODO(temp): remove when user account self-management is implemented
-    shirt_size: str | None = None
-    dietary_restriction: str | None = None
-    university: str | None = None
-    major: str | None = None
-    employer: str | None = None
-    student_status: str | None = None
-    competition_exp: str | None = None
-    volunteering_exp: str | None = None
-
     @field_validator("status")
     @classmethod
     def validate_status(cls, v: str) -> str:

--- a/backend/app/schemas/tournament_membership.py
+++ b/backend/app/schemas/tournament_membership.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from datetime import datetime
-from typing import Any
+from typing import Any, Optional
 from pydantic import BaseModel, field_validator
 
 VALID_STATUSES = {"interested", "confirmed", "declined", "assigned", "removed"}
@@ -46,7 +46,7 @@ class MembershipBase(BaseModel):
     availability: list[AvailabilitySlot] | None = None
 
     lunch_order: LunchOrderValue | None = None
-    notes: str | None = None
+    notes: Optional[str] = None
 
     # Catch-all for tournament-specific fields defined in volunteer_schema.custom_fields.
     # Anything tournament-specific that doesn't map to a standard field lives here —
@@ -71,12 +71,12 @@ class MembershipUpdate(BaseModel):
     assigned_event_id: int | None = None
     positions: list[str] | None = None
     schedule: list[ScheduleSlot] | None = None
-    status: str | None = None
+    status: Optional[str] = None
     role_preference: list[str] | None = None
     event_preference: list[str] | None = None
     availability: list[AvailabilitySlot] | None = None
     lunch_order: LunchOrderValue | None = None
-    notes: str | None = None
+    notes: Optional[str] = None
     extra_data: dict | None = None
 
     @field_validator("status")
@@ -89,6 +89,10 @@ class MembershipUpdate(BaseModel):
 
 class MembershipRead(MembershipBase):
     id: int
+
+    is_over_18: Optional[bool] = None
+    is_over_21: Optional[bool] = None
+
     created_at: datetime
     updated_at: datetime
 
@@ -105,7 +109,7 @@ class MembershipReadFlat(MembershipRead):
     # page is built, the full user profile (beyond identity) should continue
     # to come from User, not Membership.
     """
-    first_name: str | None = None
-    last_name: str | None = None
-    email: str | None = None
-    phone: str | None = None
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    email: Optional[str] = None
+    phone: Optional[str] = None

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from typing import Optional, Literal
-from datetime import datetime
+from datetime import datetime, date
 from pydantic import BaseModel, EmailStr, field_validator, computed_field
 from app.core.phone import normalize_phone as _normalize_phone
 
@@ -15,6 +15,8 @@ class UserUpdate(BaseModel):
     last_name: Optional[str] = None
     email: Optional[EmailStr] = None
     phone: Optional[str] = None
+    date_of_birth: Optional[date] = None
+    pronouns: Optional[str] = None
 
     student_status: Optional[STUDENT_STATUS] = None
     university: Optional[str] = None
@@ -23,9 +25,9 @@ class UserUpdate(BaseModel):
     graduation_year: Optional[int] = None
 
     employer: Optional[str] = None
-    
-    competition_exp: Optional[str] = None
-    volunteering_exp: Optional[str] = None
+
+    has_competition_experience: Optional[bool] = None
+    has_volunteer_experience: Optional[bool] = None
 
     shirt_size: Optional[str] = None
     dietary_restriction: Optional[str] = None
@@ -46,12 +48,16 @@ class AdminUserUpdate(BaseModel):
     role: Optional[Literal["user", "admin"]] = None
     is_active: Optional[bool] = None
 
-class UserResponse(BaseModel):
+class UserBaseResponse(BaseModel):
     id: int
     first_name: str
     last_name: str
     email: EmailStr
     phone: Optional[str] = None
+    pronouns: Optional[str] = None
+
+    is_over_18: Optional[bool] = None
+    is_over_21: Optional[bool] = None
 
     email_verified: bool
     role: ROLE
@@ -64,9 +70,9 @@ class UserResponse(BaseModel):
     graduation_year: Optional[int] = None
 
     employer: Optional[str] = None
-    
-    competition_exp: Optional[str] = None
-    volunteering_exp: Optional[str] = None
+
+    has_competition_experience: Optional[bool] = None
+    has_volunteer_experience: Optional[bool] = None
 
     shirt_size: Optional[str] = None
     dietary_restriction: Optional[str] = None
@@ -76,10 +82,20 @@ class UserResponse(BaseModel):
 
     model_config = {"from_attributes": True}
 
+    
+
+class UserMeSlimResponse(UserBaseResponse):
+    date_of_birth: date
+
+class UserSlimResponse(UserBaseResponse):
+    pass
+
+
+class UserFullResponse(UserSlimResponse):
     @computed_field
     @property
     def missing_profile_fields(self) -> list[str]:
-        always_required = ["phone", "competition_exp", "volunteering_exp", "shirt_size", "dietary_restriction"]
+        always_required = ["phone", "date_of_birth", "pronouns", "shirt_size", "dietary_restriction"]
         missing = [f for f in always_required if not getattr(self, f)]
 
         if not self.student_status:
@@ -93,5 +109,14 @@ class UserResponse(BaseModel):
                 if not getattr(self, f):
                     missing.append(f)
             
+        for flag, field_name in [
+            (self.has_competition_experience, "has_competition_experience"),
+            (self.has_volunteer_experience, "has_volunteer_experience"),
+        ]:
+            if flag is None:
+                missing.append(field_name)
 
         return missing
+    
+class UserMeFullResponse(UserFullResponse):
+    date_of_birth: date

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -70,7 +70,7 @@ class UserSlimResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 class UserMeSlimResponse(UserSlimResponse):
-    is_profile_complete: bool
+    is_profile_complete: bool = False
 
 
 
@@ -93,5 +93,5 @@ class UserFullResponse(UserSlimResponse):
     dietary_restriction: Optional[str] = None
     
 class UserMeFullResponse(UserFullResponse):
-    date_of_birth: date
+    date_of_birth: Optional[date] = None
     missing_profile_fields: list[str] = []

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -60,26 +60,9 @@ class UserSlimResponse(BaseModel):
     phone: Optional[str] = None
     pronouns: Optional[str] = None
 
-    is_over_18: Optional[bool] = None
-    is_over_21: Optional[bool] = None
-
     email_verified: bool
     role: ROLE
     is_active: bool
-    
-    student_status: Optional[STUDENT_STATUS] = None
-    university: Optional[str] = None
-    major: Optional[str] = None
-    year_level: Optional[int] = None
-    graduation_year: Optional[int] = None
-
-    employer: Optional[str] = None
-
-    has_competition_experience: Optional[bool] = None
-    has_volunteer_experience: Optional[bool] = None
-
-    shirt_size: Optional[str] = None
-    dietary_restriction: Optional[str] = None
 
     created_at: datetime
     updated_at: datetime
@@ -92,8 +75,22 @@ class UserMeSlimResponse(UserSlimResponse):
 
 
 class UserFullResponse(UserSlimResponse):
+    student_status: Optional[STUDENT_STATUS] = None
+    university: Optional[str] = None
+    major: Optional[str] = None
+    year_level: Optional[int] = None
+    graduation_year: Optional[int] = None
+
+    employer: Optional[str] = None
+
+    has_competition_experience: Optional[bool] = None
+    has_volunteer_experience: Optional[bool] = None
+
     competition_experience: list[CompetitionExperienceResponse] = []
     volunteer_experience: list[VolunteerExperienceResponse] = []
+
+    shirt_size: Optional[str] = None
+    dietary_restriction: Optional[str] = None
     
 class UserMeFullResponse(UserFullResponse):
     date_of_birth: date

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 from typing import Optional, Literal
 from datetime import datetime, date
 from pydantic import BaseModel, EmailStr, field_validator, computed_field
+
 from app.core.phone import normalize_phone as _normalize_phone
+from app.schemas.user_experience import CompetitionExperienceResponse, VolunteerExperienceResponse
 
 
 ROLE = Literal["admin", "user"]
@@ -48,7 +50,9 @@ class AdminUserUpdate(BaseModel):
     role: Optional[Literal["user", "admin"]] = None
     is_active: Optional[bool] = None
 
-class UserBaseResponse(BaseModel):
+    
+
+class UserSlimResponse(BaseModel):
     id: int
     first_name: str
     last_name: str
@@ -82,16 +86,18 @@ class UserBaseResponse(BaseModel):
 
     model_config = {"from_attributes": True}
 
-    
-
-class UserMeSlimResponse(UserBaseResponse):
+class UserMeSlimResponse(UserSlimResponse):
     date_of_birth: date
 
-class UserSlimResponse(UserBaseResponse):
-    pass
 
 
 class UserFullResponse(UserSlimResponse):
+    competition_experience: list[CompetitionExperienceResponse] = []
+    volunteer_experience: list[VolunteerExperienceResponse] = []
+    
+class UserMeFullResponse(UserFullResponse):
+    date_of_birth: date
+
     @computed_field
     @property
     def missing_profile_fields(self) -> list[str]:
@@ -109,14 +115,13 @@ class UserFullResponse(UserSlimResponse):
                 if not getattr(self, f):
                     missing.append(f)
             
-        for flag, field_name in [
-            (self.has_competition_experience, "has_competition_experience"),
-            (self.has_volunteer_experience, "has_volunteer_experience"),
+        for flag, field_name, exp_list in [
+            (self.has_competition_experience, "has_competition_experience", self.competition_experience),
+            (self.has_volunteer_experience, "has_volunteer_experience", self.volunteer_experience),
         ]:
             if flag is None:
                 missing.append(field_name)
+            elif flag is True and not exp_list:
+                missing.append(field_name)
 
         return missing
-    
-class UserMeFullResponse(UserFullResponse):
-    date_of_birth: date

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -70,7 +70,7 @@ class UserSlimResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 class UserMeSlimResponse(UserSlimResponse):
-    date_of_birth: date
+    is_profile_complete: bool
 
 
 
@@ -94,31 +94,4 @@ class UserFullResponse(UserSlimResponse):
     
 class UserMeFullResponse(UserFullResponse):
     date_of_birth: date
-
-    @computed_field
-    @property
-    def missing_profile_fields(self) -> list[str]:
-        always_required = ["phone", "date_of_birth", "pronouns", "shirt_size", "dietary_restriction"]
-        missing = [f for f in always_required if not getattr(self, f)]
-
-        if not self.student_status:
-            missing.append("student_status")
-        elif self.student_status == "Non-Student":
-            if not self.employer:
-                missing.append("employer")
-        else:
-            school_required = ["university", "major", "year_level", "graduation_year"]
-            for f in school_required:
-                if not getattr(self, f):
-                    missing.append(f)
-            
-        for flag, field_name, exp_list in [
-            (self.has_competition_experience, "has_competition_experience", self.competition_experience),
-            (self.has_volunteer_experience, "has_volunteer_experience", self.volunteer_experience),
-        ]:
-            if flag is None:
-                missing.append(field_name)
-            elif flag is True and not exp_list:
-                missing.append(field_name)
-
-        return missing
+    missing_profile_fields: list[str] = []

--- a/backend/app/schemas/user_experience.py
+++ b/backend/app/schemas/user_experience.py
@@ -1,0 +1,28 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class CompetitionExperienceResponse(BaseModel):
+    id: int
+    event_id: int
+    school: str
+    notes: Optional[str] = None
+
+    model_config = {"from_attributes": True}
+
+
+class VolunteerExperienceNotes(BaseModel):
+    event: Optional[str] = None
+    other: Optional[str] = None
+
+class VolunteerExperienceResponse(BaseModel):
+    id: int
+    
+    tournament_name: str
+    year: int
+    event_id: Optional[int] = None
+    role: str
+
+    notes: Optional[VolunteerExperienceNotes] = None
+
+    model_config = {"from_attributes": True}

--- a/backend/app/schemas/user_experience.py
+++ b/backend/app/schemas/user_experience.py
@@ -1,6 +1,16 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 from typing import Optional
 
+
+class CompetitionExperienceCreate(BaseModel):
+    event_id: int
+    school: str
+    notes: Optional[str] = None
+
+class CompetitionExperienceUpdate(BaseModel):
+    event_id: Optional[int] = None
+    school: Optional[str] = None
+    notes: Optional[str] = None
 
 class CompetitionExperienceResponse(BaseModel):
     id: int
@@ -14,6 +24,26 @@ class CompetitionExperienceResponse(BaseModel):
 class VolunteerExperienceNotes(BaseModel):
     event: Optional[str] = None
     other: Optional[str] = None
+
+class VolunteerExperienceCreate(BaseModel):
+    tournament_name: str
+    year: int
+    event_id: Optional[int] = None
+    role: str
+    notes: Optional[VolunteerExperienceNotes] = None
+
+    @model_validator(mode="after")
+    def check_event_exclusivity(self):
+        if self.event_id is not None and self.notes and self.notes.event:
+            raise ValueError("event_id and notes.event are mutually exclusive")
+        return self
+
+class VolunteerExperienceUpdate(BaseModel):
+    tournament_name: Optional[str] = None
+    year: Optional[int] = None
+    event_id: Optional[int] = None
+    role: Optional[str] = None
+    notes: Optional[VolunteerExperienceNotes] = None
 
 class VolunteerExperienceResponse(BaseModel):
     id: int

--- a/backend/app/services/sync_service.py
+++ b/backend/app/services/sync_service.py
@@ -16,7 +16,7 @@ from typing import Any
 
 from sqlalchemy.orm import Session
 
-from app.models.models import Event, Membership, SheetConfig, Tournament, User
+from app.models.models import Event, TournamentMembership, SheetConfig, Tournament, User
 from app.core.phone import normalize_phone
 from app.schemas.sheet_config import (
     PARSE_TIME_RANGE_ACTIONS,
@@ -616,9 +616,9 @@ def sync_sheet(
                 db.add(user)
                 db.flush()
 
-            membership = db.query(Membership).filter(
-                Membership.user_id == user.id,
-                Membership.tournament_id == tournament.id,
+            membership = db.query(TournamentMembership).filter(
+                TournamentMembership.user_id == user.id,
+                TournamentMembership.tournament_id == tournament.id,
             ).first()
 
             merged_availability = _merge_availability([], availability_slots)
@@ -632,7 +632,7 @@ def sync_sheet(
                 membership.extra_data = existing_extra
                 updated += 1
             else:
-                membership = Membership(
+                membership = TournamentMembership(
                     user_id=user.id,
                     tournament_id=tournament.id,
                     status="interested",

--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -11,6 +11,8 @@ def inactive_user(db):
     user = User(
         email="inactive@test.com",
         hashed_password=hash_password("pass"),
+        first_name="Inactive",
+        last_name="User",
         role="user",
         is_active=False,
     )
@@ -22,7 +24,13 @@ def inactive_user(db):
 
 @pytest.fixture
 def volunteer_no_password(db):
-    user = User(email="vol@test.com", role="user", is_active=True)
+    user = User(
+        email="vol@test.com",
+        first_name="Volunteer",
+        last_name="NoPassword",
+        role="user",
+        is_active=True,
+    )
     db.add(user)
     db.commit()
     db.refresh(user)

--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -3,6 +3,7 @@ import pytest
 from fastapi.testclient import TestClient
 from tests.conftest import login
 from app.core.auth import hash_password
+from app.core.email_verification import generate_verification_token
 from app.models.models import User
 
 
@@ -87,6 +88,9 @@ class TestLogout:
         login(client, "td@test.com", "tdpass")
         client.post("/auth/logout/")
         assert client.get("/auth/me/").status_code == 401
+
+    def test_logout_without_session_still_succeeds(self, client):
+        assert client.post("/auth/logout/").status_code == 200
 
 
 # ---------------------------------------------------------------------------
@@ -179,6 +183,24 @@ class TestRegister:
             "first_name": "New",
             "last_name": "User",
         }).status_code == 409
+
+    def test_register_duplicate_email_case_insensitive_rejected(self, client, td_user):
+        assert client.post("/auth/register/", json={
+            "email": "TD@TEST.COM",
+            "phone": VALID_PHONE,
+            "password": VALID_PASSWORD,
+            "first_name": "New",
+            "last_name": "User",
+        }).status_code == 409
+
+    def test_register_invalid_phone_rejected(self, client):
+        assert client.post("/auth/register/", json={
+            "email": "new@test.com",
+            "phone": "notaphone",
+            "password": VALID_PASSWORD,
+            "first_name": "New",
+            "last_name": "User",
+        }).status_code == 422
 
     def test_register_can_login_with_new_credentials(self, client):
         # Confirms the password was hashed and stored correctly
@@ -318,3 +340,43 @@ class TestAdminRegister:
             "last_name": "User",
             "role": "superuser",
         }).status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /auth/verify-email/
+# ---------------------------------------------------------------------------
+
+class TestVerifyEmail:
+    def test_valid_token_verifies_email(self, client, td_user, db):
+        assert td_user.email_verified is False
+        token = generate_verification_token(td_user.id)
+        res = client.get(f"/auth/verify-email/?token={token}")
+        assert res.status_code == 200
+        db.refresh(td_user)
+        assert td_user.email_verified is True
+
+    def test_invalid_token_rejected(self, client):
+        assert client.get("/auth/verify-email/?token=garbage").status_code == 400
+
+    def test_token_for_nonexistent_user_not_found(self, client):
+        token = generate_verification_token(9999)
+        assert client.get(f"/auth/verify-email/?token={token}").status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /auth/send-email-verification/
+# ---------------------------------------------------------------------------
+
+class TestSendEmailVerification:
+    def test_unverified_user_can_request(self, client, td_user):
+        login(client, "td@test.com", "tdpass")
+        assert client.post("/auth/send-email-verification/").status_code == 200
+
+    def test_already_verified_rejected(self, client, td_user, db):
+        td_user.email_verified = True
+        db.commit()
+        login(client, "td@test.com", "tdpass")
+        assert client.post("/auth/send-email-verification/").status_code == 400
+
+    def test_unauthenticated_forbidden(self, client):
+        assert client.post("/auth/send-email-verification/").status_code == 401

--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -87,30 +87,30 @@ class TestLogout:
     def test_cannot_access_me_after_logout(self, client, td_user):
         login(client, "td@test.com", "tdpass")
         client.post("/auth/logout/")
-        assert client.get("/auth/me/").status_code == 401
+        assert client.get("/users/me/").status_code == 401
 
     def test_logout_without_session_still_succeeds(self, client):
         assert client.post("/auth/logout/").status_code == 200
 
 
 # ---------------------------------------------------------------------------
-# GET /auth/me/
+# GET /users/me/ (default, no ?full) — slim shape, folded in from old /auth/me/
 # ---------------------------------------------------------------------------
 
 class TestMe:
     def test_me_returns_current_user(self, client, td_user):
         login(client, "td@test.com", "tdpass")
-        res = client.get("/auth/me/")
+        res = client.get("/users/me/")
         assert res.status_code == 200
         assert res.json()["email"] == "td@test.com"
         assert res.json()["role"] == "user"
 
     def test_me_unauthenticated(self, client):
-        assert client.get("/auth/me/").status_code == 401
+        assert client.get("/users/me/").status_code == 401
 
     def test_me_admin_role(self, client, admin_user):
         login(client, "admin@test.com", "adminpass")
-        res = client.get("/auth/me/")
+        res = client.get("/users/me/")
         assert res.status_code == 200
         assert res.json()["role"] == "admin"
 
@@ -160,7 +160,7 @@ class TestRegister:
             "first_name": "New",
             "last_name": "User",
         })
-        res = client.get("/auth/me/")
+        res = client.get("/users/me/")
         assert res.status_code == 200
         assert res.json()["email"] == "new@test.com"
 

--- a/backend/tests/api/test_events.py
+++ b/backend/tests/api/test_events.py
@@ -1,218 +1,243 @@
-"""Tests for /tournaments/{tournament_id}/events endpoints."""
-import pytest
-from fastapi.testclient import TestClient
+"""Tests for the canonical /events/ and /event-categories/ routes."""
 from tests.conftest import login
-from app.models.models import Membership
+from app.models.models import Event, EventCategory, UserCompetitionExperience, UserVolunteerExperience
 
 
-def _make_event(client, tournament_id, **overrides):
-    payload = {
-        "tournament_id": tournament_id,
-        "name": "Boomilever",
-        "division": "C",
-        "blocks": [1, 2, 3, 4, 5, 6],
-    }
-    payload.update(overrides)
-    return client.post(f"/tournaments/{tournament_id}/events/", json=payload)
-
-
-# ---------------------------------------------------------------------------
-# Create
-# ---------------------------------------------------------------------------
-
-def test_create_event_minimal(client, td_user, td_tournament):
-    login(client, "td@test.com", "tdpass")
-    response = _make_event(client, td_tournament.id)
-    assert response.status_code == 201
-    data = response.json()
-    assert data["name"] == "Boomilever"
-    assert data["division"] == "C"
-    assert data["tournament_id"] == td_tournament.id
-    assert data["event_type"] == "standard"
-    assert data["volunteers_needed"] == 2
-
-
-def test_create_event_full(client, td_user, td_tournament):
-    login(client, "td@test.com", "tdpass")
-    response = _make_event(client, td_tournament.id,
-        name="Hovercraft", division="B", event_type="trial",
-        category="Technology & Engineering", building="Main Hall",
-        room="101", floor="1", volunteers_needed=3, blocks=[1, 2, 3],
-    )
-    assert response.status_code == 201
-    data = response.json()
-    assert data["category"] == "Technology & Engineering"
-    assert data["volunteers_needed"] == 3
-    assert data["event_type"] == "trial"
-
-
-def test_create_event_duplicate_rejected(client, td_user, td_tournament):
-    login(client, "td@test.com", "tdpass")
-    _make_event(client, td_tournament.id)
-    assert _make_event(client, td_tournament.id).status_code == 409
-
-
-def test_create_event_tournament_id_mismatch(client, td_user, td_tournament):
-    login(client, "td@test.com", "tdpass")
-    response = client.post(f"/tournaments/{td_tournament.id}/events/", json={
-        "tournament_id": 9999,
-        "name": "Boomilever",
-        "division": "C",
-        "blocks": [],
-    })
-    assert response.status_code == 400
-
-
-def test_create_event_non_member_forbidden(client, td_user, other_tournament):
-    """Non-members get 403 on write routes — permission check fires before existence check."""
-    login(client, "td@test.com", "tdpass")
-    assert _make_event(client, other_tournament.id).status_code == 403
-
-
-def test_create_event_volunteer_member_forbidden(
-    client, td_user, other_tournament, db
-):
-    db.add(Membership(
-        user_id=td_user.id,
-        tournament_id=other_tournament.id,
-        positions=["event_supervisor"],
-        status="confirmed",
-    ))
+def _make_category(db, name="Chemistry"):
+    category = EventCategory(name=name)
+    db.add(category)
     db.commit()
-    login(client, "td@test.com", "tdpass")
-    assert _make_event(client, other_tournament.id).status_code == 403
+    db.refresh(category)
+    return category
 
 
-def test_create_event_unauthenticated(client, td_tournament):
-    assert _make_event(client, td_tournament.id).status_code == 401
-
-
-# ---------------------------------------------------------------------------
-# List
-# ---------------------------------------------------------------------------
-
-def test_list_events(client, td_user, td_tournament):
-    login(client, "td@test.com", "tdpass")
-    _make_event(client, td_tournament.id, name="Boomilever", division="C")
-    _make_event(client, td_tournament.id, name="Hovercraft", division="C")
-    response = client.get(f"/tournaments/{td_tournament.id}/events/")
-    assert response.status_code == 200
-    assert len(response.json()) == 2
-
-
-def test_list_events_ordered_by_division_name(client, td_user, td_tournament):
-    login(client, "td@test.com", "tdpass")
-    _make_event(client, td_tournament.id, name="Hovercraft", division="C")
-    _make_event(client, td_tournament.id, name="Boomilever", division="C")
-    _make_event(client, td_tournament.id, name="Anatomy", division="B")
-    names = [e["name"] for e in client.get(f"/tournaments/{td_tournament.id}/events/").json()]
-    assert names[0] == "Anatomy"
-    assert names[1] == "Boomilever"
-    assert names[2] == "Hovercraft"
-
-
-def test_list_events_view_events_permission_sufficient(
-    client, td_user, other_tournament, db
-):
-    db.add(Membership(
-        user_id=td_user.id,
-        tournament_id=other_tournament.id,
-        positions=["event_supervisor"],
-        status="confirmed",
-    ))
+def _make_event(db, category, name="Boomilever"):
+    event = Event(name=name, category_id=category.id)
+    db.add(event)
     db.commit()
-    login(client, "td@test.com", "tdpass")
-    assert client.get(f"/tournaments/{other_tournament.id}/events/").status_code == 200
-
-
-def test_list_events_non_member_gets_404(client, td_user, other_tournament):
-    login(client, "td@test.com", "tdpass")
-    assert client.get(f"/tournaments/{other_tournament.id}/events/").status_code == 404
+    db.refresh(event)
+    return event
 
 
 # ---------------------------------------------------------------------------
-# Get single
+# GET /events/
 # ---------------------------------------------------------------------------
 
-def test_get_event(client, td_user, td_tournament):
-    login(client, "td@test.com", "tdpass")
-    created = _make_event(client, td_tournament.id).json()
-    response = client.get(f"/tournaments/{td_tournament.id}/events/{created['id']}/")
-    assert response.status_code == 200
-    assert response.json()["name"] == "Boomilever"
+class TestListEvents:
+    def test_list_events(self, client, db):
+        category = _make_category(db)
+        _make_event(db, category)
+        res = client.get("/events/")
+        assert res.status_code == 200
+        assert len(res.json()) == 1
 
-
-def test_get_event_wrong_tournament_404(
-    client, td_user, td_tournament, other_user, other_tournament, db
-):
-    db.add(Membership(
-        user_id=td_user.id,
-        tournament_id=other_tournament.id,
-        positions=["event_supervisor"],
-        status="confirmed",
-    ))
-    db.commit()
-    login(client, "td@test.com", "tdpass")
-    event = _make_event(client, td_tournament.id).json()
-    assert client.get(
-        f"/tournaments/{other_tournament.id}/events/{event['id']}/"
-    ).status_code == 404
-
-
-def test_get_event_not_found(client, td_user, td_tournament):
-    login(client, "td@test.com", "tdpass")
-    assert client.get(f"/tournaments/{td_tournament.id}/events/9999/").status_code == 404
+    def test_list_events_anonymous_allowed(self, client, db):
+        category = _make_category(db)
+        _make_event(db, category)
+        assert client.get("/events/").status_code == 200
 
 
 # ---------------------------------------------------------------------------
-# PATCH
+# POST /events/
 # ---------------------------------------------------------------------------
 
-def test_update_event(client, td_user, td_tournament):
-    login(client, "td@test.com", "tdpass")
-    created = _make_event(client, td_tournament.id).json()
-    response = client.patch(
-        f"/tournaments/{td_tournament.id}/events/{created['id']}/",
-        json={"building": "Science Hall", "room": "204"},
-    )
-    assert response.status_code == 200
-    assert response.json()["building"] == "Science Hall"
+class TestCreateEvent:
+    def test_admin_can_create_event(self, client, db, admin_user):
+        category = _make_category(db)
+        login(client, "admin@test.com", "adminpass")
+        res = client.post("/events/", json={"name": "Boomilever", "category_id": category.id})
+        assert res.status_code == 201
+        data = res.json()
+        assert data["name"] == "Boomilever"
+        assert data["category_id"] == category.id
 
+    def test_non_admin_forbidden(self, client, db, td_user):
+        category = _make_category(db)
+        login(client, "td@test.com", "tdpass")
+        res = client.post("/events/", json={"name": "Boomilever", "category_id": category.id})
+        assert res.status_code == 403
 
-def test_update_event_volunteer_cannot_patch(
-    client, td_user, other_user, other_tournament, db
-):
-    db.add(Membership(
-        user_id=td_user.id,
-        tournament_id=other_tournament.id,
-        positions=["event_supervisor"],
-        status="confirmed",
-    ))
-    db.commit()
-    login(client, "other@test.com", "otherpass")
-    event = _make_event(client, other_tournament.id).json()
-    login(client, "td@test.com", "tdpass")
-    assert client.patch(
-        f"/tournaments/{other_tournament.id}/events/{event['id']}/",
-        json={"room": "999"},
-    ).status_code == 403
+    def test_unauthenticated_forbidden(self, client, db):
+        category = _make_category(db)
+        res = client.post("/events/", json={"name": "Boomilever", "category_id": category.id})
+        assert res.status_code == 401
+
+    def test_invalid_category_id_404(self, client, db, admin_user):
+        login(client, "admin@test.com", "adminpass")
+        res = client.post("/events/", json={"name": "Boomilever", "category_id": 9999})
+        assert res.status_code == 404
 
 
 # ---------------------------------------------------------------------------
-# DELETE
+# PATCH /events/{id}/
 # ---------------------------------------------------------------------------
 
-def test_delete_event(client, td_user, td_tournament):
-    login(client, "td@test.com", "tdpass")
-    created = _make_event(client, td_tournament.id).json()
-    assert client.delete(
-        f"/tournaments/{td_tournament.id}/events/{created['id']}/"
-    ).status_code == 204
-    assert client.get(
-        f"/tournaments/{td_tournament.id}/events/{created['id']}/"
-    ).status_code == 404
+class TestUpdateEvent:
+    def test_partial_update(self, client, db, admin_user):
+        category = _make_category(db)
+        event = _make_event(db, category)
+        login(client, "admin@test.com", "adminpass")
+        res = client.patch(f"/events/{event.id}/", json={"name": "Hovercraft"})
+        assert res.status_code == 200
+        assert res.json()["name"] == "Hovercraft"
+
+    def test_update_category_id(self, client, db, admin_user):
+        category = _make_category(db, "Chemistry")
+        other_category = _make_category(db, "Physics")
+        event = _make_event(db, category)
+        login(client, "admin@test.com", "adminpass")
+        res = client.patch(f"/events/{event.id}/", json={"category_id": other_category.id})
+        assert res.status_code == 200
+        assert res.json()["category_id"] == other_category.id
+
+    def test_missing_event_404(self, client, db, admin_user):
+        login(client, "admin@test.com", "adminpass")
+        assert client.patch("/events/9999/", json={"name": "Hovercraft"}).status_code == 404
+
+    def test_invalid_category_id_404(self, client, db, admin_user):
+        category = _make_category(db)
+        event = _make_event(db, category)
+        login(client, "admin@test.com", "adminpass")
+        res = client.patch(f"/events/{event.id}/", json={"category_id": 9999})
+        assert res.status_code == 404
+
+    def test_non_admin_forbidden(self, client, db, td_user):
+        category = _make_category(db)
+        event = _make_event(db, category)
+        login(client, "td@test.com", "tdpass")
+        assert client.patch(f"/events/{event.id}/", json={"name": "Hovercraft"}).status_code == 403
 
 
-def test_delete_event_not_found(client, td_user, td_tournament):
-    login(client, "td@test.com", "tdpass")
-    assert client.delete(f"/tournaments/{td_tournament.id}/events/9999/").status_code == 404
+# ---------------------------------------------------------------------------
+# DELETE /events/{id}/
+# ---------------------------------------------------------------------------
+
+class TestDeleteEvent:
+    def test_delete_with_no_experience_entries(self, client, db, admin_user):
+        category = _make_category(db)
+        event = _make_event(db, category)
+        login(client, "admin@test.com", "adminpass")
+        assert client.delete(f"/events/{event.id}/").status_code == 204
+        assert db.get(Event, event.id) is None
+
+    def test_delete_blocked_by_competition_experience(self, client, db, admin_user, td_user):
+        category = _make_category(db)
+        event = _make_event(db, category)
+        db.add(UserCompetitionExperience(user_id=td_user.id, event_id=event.id, school="MIT"))
+        db.commit()
+        login(client, "admin@test.com", "adminpass")
+        res = client.delete(f"/events/{event.id}/")
+        assert res.status_code == 409
+        assert db.get(Event, event.id) is not None
+
+    def test_delete_blocked_by_volunteer_experience(self, client, db, admin_user, td_user):
+        category = _make_category(db)
+        event = _make_event(db, category)
+        db.add(UserVolunteerExperience(
+            user_id=td_user.id, event_id=event.id,
+            tournament_name="Regionals", year=2025, role="Event Supervisor",
+        ))
+        db.commit()
+        login(client, "admin@test.com", "adminpass")
+        res = client.delete(f"/events/{event.id}/")
+        assert res.status_code == 409
+        assert db.get(Event, event.id) is not None
+
+    def test_delete_not_found(self, client, db, admin_user):
+        login(client, "admin@test.com", "adminpass")
+        assert client.delete("/events/9999/").status_code == 404
+
+    def test_non_admin_forbidden(self, client, db, td_user):
+        category = _make_category(db)
+        event = _make_event(db, category)
+        login(client, "td@test.com", "tdpass")
+        assert client.delete(f"/events/{event.id}/").status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# GET /event-categories/
+# ---------------------------------------------------------------------------
+
+class TestListEventCategories:
+    def test_list_categories(self, client, db):
+        _make_category(db)
+        res = client.get("/event-categories/")
+        assert res.status_code == 200
+        assert len(res.json()) == 1
+
+
+# ---------------------------------------------------------------------------
+# POST /event-categories/
+# ---------------------------------------------------------------------------
+
+class TestCreateEventCategory:
+    def test_admin_can_create_category(self, client, db, admin_user):
+        login(client, "admin@test.com", "adminpass")
+        res = client.post("/event-categories/", json={"name": "Chemistry"})
+        assert res.status_code == 201
+        assert res.json()["name"] == "Chemistry"
+
+    def test_non_admin_forbidden(self, client, db, td_user):
+        login(client, "td@test.com", "tdpass")
+        assert client.post("/event-categories/", json={"name": "Chemistry"}).status_code == 403
+
+    def test_unauthenticated_forbidden(self, client, db):
+        assert client.post("/event-categories/", json={"name": "Chemistry"}).status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# PATCH /event-categories/{id}/
+# ---------------------------------------------------------------------------
+
+class TestUpdateEventCategory:
+    def test_partial_update(self, client, db, admin_user):
+        category = _make_category(db, "Chemistry")
+        login(client, "admin@test.com", "adminpass")
+        res = client.patch(f"/event-categories/{category.id}/", json={"name": "Physics"})
+        assert res.status_code == 200
+        assert res.json()["name"] == "Physics"
+
+    def test_missing_category_404(self, client, db, admin_user):
+        login(client, "admin@test.com", "adminpass")
+        assert client.patch("/event-categories/9999/", json={"name": "Physics"}).status_code == 404
+
+    def test_non_admin_forbidden(self, client, db, td_user):
+        category = _make_category(db)
+        login(client, "td@test.com", "tdpass")
+        res = client.patch(f"/event-categories/{category.id}/", json={"name": "Physics"})
+        assert res.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# DELETE /event-categories/{id}/
+# ---------------------------------------------------------------------------
+
+class TestDeleteEventCategory:
+    def test_delete_cascades_to_events(self, client, db, admin_user):
+        category = _make_category(db)
+        event = _make_event(db, category)
+        login(client, "admin@test.com", "adminpass")
+        assert client.delete(f"/event-categories/{category.id}/").status_code == 204
+        assert db.get(EventCategory, category.id) is None
+        assert db.get(Event, event.id) is None
+
+    def test_delete_blocked_when_event_has_experience_entries(self, client, db, admin_user, td_user):
+        category = _make_category(db)
+        event = _make_event(db, category)
+        db.add(UserCompetitionExperience(user_id=td_user.id, event_id=event.id, school="MIT"))
+        db.commit()
+        login(client, "admin@test.com", "adminpass")
+        res = client.delete(f"/event-categories/{category.id}/")
+        assert res.status_code == 409
+        # Rollback — category and its event should still exist.
+        assert db.get(EventCategory, category.id) is not None
+        assert db.get(Event, event.id) is not None
+
+    def test_delete_not_found(self, client, db, admin_user):
+        login(client, "admin@test.com", "adminpass")
+        assert client.delete("/event-categories/9999/").status_code == 404
+
+    def test_non_admin_forbidden(self, client, db, td_user):
+        category = _make_category(db)
+        login(client, "td@test.com", "tdpass")
+        assert client.delete(f"/event-categories/{category.id}/").status_code == 403

--- a/backend/tests/api/test_events.py
+++ b/backend/tests/api/test_events.py
@@ -3,37 +3,21 @@ from tests.conftest import login
 from app.models.models import Event, EventCategory, UserCompetitionExperience, UserVolunteerExperience
 
 
-def _make_category(db, name="Chemistry"):
-    category = EventCategory(name=name)
-    db.add(category)
-    db.commit()
-    db.refresh(category)
-    return category
-
-
-def _make_event(db, category, name="Boomilever"):
-    event = Event(name=name, category_id=category.id)
-    db.add(event)
-    db.commit()
-    db.refresh(event)
-    return event
-
-
 # ---------------------------------------------------------------------------
 # GET /events/
 # ---------------------------------------------------------------------------
 
 class TestListEvents:
-    def test_list_events(self, client, db):
-        category = _make_category(db)
-        _make_event(db, category)
+    def test_list_events(self, client, event_category_factory, event_factory):
+        category = event_category_factory()
+        event_factory(category)
         res = client.get("/events/")
         assert res.status_code == 200
         assert len(res.json()) == 1
 
-    def test_list_events_anonymous_allowed(self, client, db):
-        category = _make_category(db)
-        _make_event(db, category)
+    def test_list_events_anonymous_allowed(self, client, event_category_factory, event_factory):
+        category = event_category_factory()
+        event_factory(category)
         assert client.get("/events/").status_code == 200
 
 
@@ -42,27 +26,24 @@ class TestListEvents:
 # ---------------------------------------------------------------------------
 
 class TestCreateEvent:
-    def test_admin_can_create_event(self, client, db, admin_user):
-        category = _make_category(db)
+    def test_admin_can_create_event(self, client, admin_user, event_category):
         login(client, "admin@test.com", "adminpass")
-        res = client.post("/events/", json={"name": "Boomilever", "category_id": category.id})
+        res = client.post("/events/", json={"name": "Boomilever", "category_id": event_category.id})
         assert res.status_code == 201
         data = res.json()
         assert data["name"] == "Boomilever"
-        assert data["category_id"] == category.id
+        assert data["category_id"] == event_category.id
 
-    def test_non_admin_forbidden(self, client, db, td_user):
-        category = _make_category(db)
+    def test_non_admin_forbidden(self, client, td_user, event_category):
         login(client, "td@test.com", "tdpass")
-        res = client.post("/events/", json={"name": "Boomilever", "category_id": category.id})
+        res = client.post("/events/", json={"name": "Boomilever", "category_id": event_category.id})
         assert res.status_code == 403
 
-    def test_unauthenticated_forbidden(self, client, db):
-        category = _make_category(db)
-        res = client.post("/events/", json={"name": "Boomilever", "category_id": category.id})
+    def test_unauthenticated_forbidden(self, client, event_category):
+        res = client.post("/events/", json={"name": "Boomilever", "category_id": event_category.id})
         assert res.status_code == 401
 
-    def test_invalid_category_id_404(self, client, db, admin_user):
+    def test_invalid_category_id_404(self, client, admin_user):
         login(client, "admin@test.com", "adminpass")
         res = client.post("/events/", json={"name": "Boomilever", "category_id": 9999})
         assert res.status_code == 404
@@ -73,37 +54,31 @@ class TestCreateEvent:
 # ---------------------------------------------------------------------------
 
 class TestUpdateEvent:
-    def test_partial_update(self, client, db, admin_user):
-        category = _make_category(db)
-        event = _make_event(db, category)
+    def test_partial_update(self, client, admin_user, event):
         login(client, "admin@test.com", "adminpass")
         res = client.patch(f"/events/{event.id}/", json={"name": "Hovercraft"})
         assert res.status_code == 200
         assert res.json()["name"] == "Hovercraft"
 
-    def test_update_category_id(self, client, db, admin_user):
-        category = _make_category(db, "Chemistry")
-        other_category = _make_category(db, "Physics")
-        event = _make_event(db, category)
+    def test_update_category_id(self, client, admin_user, event_category_factory, event_factory):
+        category = event_category_factory("Chemistry")
+        other_category = event_category_factory("Physics")
+        event = event_factory(category)
         login(client, "admin@test.com", "adminpass")
         res = client.patch(f"/events/{event.id}/", json={"category_id": other_category.id})
         assert res.status_code == 200
         assert res.json()["category_id"] == other_category.id
 
-    def test_missing_event_404(self, client, db, admin_user):
+    def test_missing_event_404(self, client, admin_user):
         login(client, "admin@test.com", "adminpass")
         assert client.patch("/events/9999/", json={"name": "Hovercraft"}).status_code == 404
 
-    def test_invalid_category_id_404(self, client, db, admin_user):
-        category = _make_category(db)
-        event = _make_event(db, category)
+    def test_invalid_category_id_404(self, client, admin_user, event):
         login(client, "admin@test.com", "adminpass")
         res = client.patch(f"/events/{event.id}/", json={"category_id": 9999})
         assert res.status_code == 404
 
-    def test_non_admin_forbidden(self, client, db, td_user):
-        category = _make_category(db)
-        event = _make_event(db, category)
+    def test_non_admin_forbidden(self, client, td_user, event):
         login(client, "td@test.com", "tdpass")
         assert client.patch(f"/events/{event.id}/", json={"name": "Hovercraft"}).status_code == 403
 
@@ -113,16 +88,12 @@ class TestUpdateEvent:
 # ---------------------------------------------------------------------------
 
 class TestDeleteEvent:
-    def test_delete_with_no_experience_entries(self, client, db, admin_user):
-        category = _make_category(db)
-        event = _make_event(db, category)
+    def test_delete_with_no_experience_entries(self, client, db, admin_user, event):
         login(client, "admin@test.com", "adminpass")
         assert client.delete(f"/events/{event.id}/").status_code == 204
         assert db.get(Event, event.id) is None
 
-    def test_delete_blocked_by_competition_experience(self, client, db, admin_user, td_user):
-        category = _make_category(db)
-        event = _make_event(db, category)
+    def test_delete_blocked_by_competition_experience(self, client, db, admin_user, td_user, event):
         db.add(UserCompetitionExperience(user_id=td_user.id, event_id=event.id, school="MIT"))
         db.commit()
         login(client, "admin@test.com", "adminpass")
@@ -130,9 +101,7 @@ class TestDeleteEvent:
         assert res.status_code == 409
         assert db.get(Event, event.id) is not None
 
-    def test_delete_blocked_by_volunteer_experience(self, client, db, admin_user, td_user):
-        category = _make_category(db)
-        event = _make_event(db, category)
+    def test_delete_blocked_by_volunteer_experience(self, client, db, admin_user, td_user, event):
         db.add(UserVolunteerExperience(
             user_id=td_user.id, event_id=event.id,
             tournament_name="Regionals", year=2025, role="Event Supervisor",
@@ -143,13 +112,11 @@ class TestDeleteEvent:
         assert res.status_code == 409
         assert db.get(Event, event.id) is not None
 
-    def test_delete_not_found(self, client, db, admin_user):
+    def test_delete_not_found(self, client, admin_user):
         login(client, "admin@test.com", "adminpass")
         assert client.delete("/events/9999/").status_code == 404
 
-    def test_non_admin_forbidden(self, client, db, td_user):
-        category = _make_category(db)
-        event = _make_event(db, category)
+    def test_non_admin_forbidden(self, client, td_user, event):
         login(client, "td@test.com", "tdpass")
         assert client.delete(f"/events/{event.id}/").status_code == 403
 
@@ -159,8 +126,7 @@ class TestDeleteEvent:
 # ---------------------------------------------------------------------------
 
 class TestListEventCategories:
-    def test_list_categories(self, client, db):
-        _make_category(db)
+    def test_list_categories(self, client, event_category):
         res = client.get("/event-categories/")
         assert res.status_code == 200
         assert len(res.json()) == 1
@@ -171,17 +137,17 @@ class TestListEventCategories:
 # ---------------------------------------------------------------------------
 
 class TestCreateEventCategory:
-    def test_admin_can_create_category(self, client, db, admin_user):
+    def test_admin_can_create_category(self, client, admin_user):
         login(client, "admin@test.com", "adminpass")
         res = client.post("/event-categories/", json={"name": "Chemistry"})
         assert res.status_code == 201
         assert res.json()["name"] == "Chemistry"
 
-    def test_non_admin_forbidden(self, client, db, td_user):
+    def test_non_admin_forbidden(self, client, td_user):
         login(client, "td@test.com", "tdpass")
         assert client.post("/event-categories/", json={"name": "Chemistry"}).status_code == 403
 
-    def test_unauthenticated_forbidden(self, client, db):
+    def test_unauthenticated_forbidden(self, client):
         assert client.post("/event-categories/", json={"name": "Chemistry"}).status_code == 401
 
 
@@ -190,21 +156,19 @@ class TestCreateEventCategory:
 # ---------------------------------------------------------------------------
 
 class TestUpdateEventCategory:
-    def test_partial_update(self, client, db, admin_user):
-        category = _make_category(db, "Chemistry")
+    def test_partial_update(self, client, admin_user, event_category):
         login(client, "admin@test.com", "adminpass")
-        res = client.patch(f"/event-categories/{category.id}/", json={"name": "Physics"})
+        res = client.patch(f"/event-categories/{event_category.id}/", json={"name": "Physics"})
         assert res.status_code == 200
         assert res.json()["name"] == "Physics"
 
-    def test_missing_category_404(self, client, db, admin_user):
+    def test_missing_category_404(self, client, admin_user):
         login(client, "admin@test.com", "adminpass")
         assert client.patch("/event-categories/9999/", json={"name": "Physics"}).status_code == 404
 
-    def test_non_admin_forbidden(self, client, db, td_user):
-        category = _make_category(db)
+    def test_non_admin_forbidden(self, client, td_user, event_category):
         login(client, "td@test.com", "tdpass")
-        res = client.patch(f"/event-categories/{category.id}/", json={"name": "Physics"})
+        res = client.patch(f"/event-categories/{event_category.id}/", json={"name": "Physics"})
         assert res.status_code == 403
 
 
@@ -213,31 +177,28 @@ class TestUpdateEventCategory:
 # ---------------------------------------------------------------------------
 
 class TestDeleteEventCategory:
-    def test_delete_cascades_to_events(self, client, db, admin_user):
-        category = _make_category(db)
-        event = _make_event(db, category)
+    def test_delete_cascades_to_events(self, client, db, admin_user, event_category, event):
         login(client, "admin@test.com", "adminpass")
-        assert client.delete(f"/event-categories/{category.id}/").status_code == 204
-        assert db.get(EventCategory, category.id) is None
+        assert client.delete(f"/event-categories/{event_category.id}/").status_code == 204
+        assert db.get(EventCategory, event_category.id) is None
         assert db.get(Event, event.id) is None
 
-    def test_delete_blocked_when_event_has_experience_entries(self, client, db, admin_user, td_user):
-        category = _make_category(db)
-        event = _make_event(db, category)
+    def test_delete_blocked_when_event_has_experience_entries(
+        self, client, db, admin_user, td_user, event_category, event
+    ):
         db.add(UserCompetitionExperience(user_id=td_user.id, event_id=event.id, school="MIT"))
         db.commit()
         login(client, "admin@test.com", "adminpass")
-        res = client.delete(f"/event-categories/{category.id}/")
+        res = client.delete(f"/event-categories/{event_category.id}/")
         assert res.status_code == 409
         # Rollback — category and its event should still exist.
-        assert db.get(EventCategory, category.id) is not None
+        assert db.get(EventCategory, event_category.id) is not None
         assert db.get(Event, event.id) is not None
 
-    def test_delete_not_found(self, client, db, admin_user):
+    def test_delete_not_found(self, client, admin_user):
         login(client, "admin@test.com", "adminpass")
         assert client.delete("/event-categories/9999/").status_code == 404
 
-    def test_non_admin_forbidden(self, client, db, td_user):
-        category = _make_category(db)
+    def test_non_admin_forbidden(self, client, td_user, event_category):
         login(client, "td@test.com", "tdpass")
-        assert client.delete(f"/event-categories/{category.id}/").status_code == 403
+        assert client.delete(f"/event-categories/{event_category.id}/").status_code == 403

--- a/backend/tests/api/test_sheets.py
+++ b/backend/tests/api/test_sheets.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 from fastapi.testclient import TestClient
 from tests.conftest import login
 from app.schemas.sheet_config import SheetValidateResponse, SheetHeadersResponse, MappedHeader
-from app.models.models import Membership
+from app.models.models import TournamentMembership
 
 FAKE_URL = "https://docs.google.com/spreadsheets/d/fake123/edit"
 FAKE_FORM_URL = "https://docs.google.com/forms/d/fake_form/edit"
@@ -66,7 +66,7 @@ def test_validate_non_member_gets_404(client, td_user, other_tournament, mock_sh
 def test_validate_volunteer_member_forbidden(
     client, td_user, other_tournament, db, mock_sheets_service
 ):
-    db.add(Membership(
+    db.add(TournamentMembership(
         user_id=td_user.id,
         tournament_id=other_tournament.id,
         positions=["event_supervisor"],
@@ -240,7 +240,7 @@ def test_get_sheet_config(client, td_user, td_tournament, mock_sheets_service):
 def test_get_sheet_config_wrong_tournament_404(
     client, td_user, td_tournament, other_tournament, db, mock_sheets_service
 ):
-    db.add(Membership(
+    db.add(TournamentMembership(
         user_id=td_user.id,
         tournament_id=other_tournament.id,
         positions=["tournament_director"],

--- a/backend/tests/api/test_tournament_events.py
+++ b/backend/tests/api/test_tournament_events.py
@@ -1,0 +1,218 @@
+"""Tests for /tournaments/{tournament_id}/events endpoints (TournamentEvent model)."""
+import pytest
+from fastapi.testclient import TestClient
+from tests.conftest import login
+from app.models.models import TournamentMembership
+
+
+def _make_event(client, tournament_id, **overrides):
+    payload = {
+        "tournament_id": tournament_id,
+        "name": "Boomilever",
+        "division": "C",
+        "blocks": [1, 2, 3, 4, 5, 6],
+    }
+    payload.update(overrides)
+    return client.post(f"/tournaments/{tournament_id}/events/", json=payload)
+
+
+# ---------------------------------------------------------------------------
+# Create
+# ---------------------------------------------------------------------------
+
+def test_create_event_minimal(client, td_user, td_tournament):
+    login(client, "td@test.com", "tdpass")
+    response = _make_event(client, td_tournament.id)
+    assert response.status_code == 201
+    data = response.json()
+    assert data["name"] == "Boomilever"
+    assert data["division"] == "C"
+    assert data["tournament_id"] == td_tournament.id
+    assert data["event_type"] == "standard"
+    assert data["volunteers_needed"] == 2
+
+
+def test_create_event_full(client, td_user, td_tournament):
+    login(client, "td@test.com", "tdpass")
+    response = _make_event(client, td_tournament.id,
+        name="Hovercraft", division="B", event_type="trial",
+        category="Technology & Engineering", building="Main Hall",
+        room="101", floor="1", volunteers_needed=3, blocks=[1, 2, 3],
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["category"] == "Technology & Engineering"
+    assert data["volunteers_needed"] == 3
+    assert data["event_type"] == "trial"
+
+
+def test_create_event_duplicate_rejected(client, td_user, td_tournament):
+    login(client, "td@test.com", "tdpass")
+    _make_event(client, td_tournament.id)
+    assert _make_event(client, td_tournament.id).status_code == 409
+
+
+def test_create_event_tournament_id_mismatch(client, td_user, td_tournament):
+    login(client, "td@test.com", "tdpass")
+    response = client.post(f"/tournaments/{td_tournament.id}/events/", json={
+        "tournament_id": 9999,
+        "name": "Boomilever",
+        "division": "C",
+        "blocks": [],
+    })
+    assert response.status_code == 400
+
+
+def test_create_event_non_member_forbidden(client, td_user, other_tournament):
+    """Non-members get 403 on write routes — permission check fires before existence check."""
+    login(client, "td@test.com", "tdpass")
+    assert _make_event(client, other_tournament.id).status_code == 403
+
+
+def test_create_event_volunteer_member_forbidden(
+    client, td_user, other_tournament, db
+):
+    db.add(TournamentMembership(
+        user_id=td_user.id,
+        tournament_id=other_tournament.id,
+        positions=["event_supervisor"],
+        status="confirmed",
+    ))
+    db.commit()
+    login(client, "td@test.com", "tdpass")
+    assert _make_event(client, other_tournament.id).status_code == 403
+
+
+def test_create_event_unauthenticated(client, td_tournament):
+    assert _make_event(client, td_tournament.id).status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# List
+# ---------------------------------------------------------------------------
+
+def test_list_events(client, td_user, td_tournament):
+    login(client, "td@test.com", "tdpass")
+    _make_event(client, td_tournament.id, name="Boomilever", division="C")
+    _make_event(client, td_tournament.id, name="Hovercraft", division="C")
+    response = client.get(f"/tournaments/{td_tournament.id}/events/")
+    assert response.status_code == 200
+    assert len(response.json()) == 2
+
+
+def test_list_events_ordered_by_division_name(client, td_user, td_tournament):
+    login(client, "td@test.com", "tdpass")
+    _make_event(client, td_tournament.id, name="Hovercraft", division="C")
+    _make_event(client, td_tournament.id, name="Boomilever", division="C")
+    _make_event(client, td_tournament.id, name="Anatomy", division="B")
+    names = [e["name"] for e in client.get(f"/tournaments/{td_tournament.id}/events/").json()]
+    assert names[0] == "Anatomy"
+    assert names[1] == "Boomilever"
+    assert names[2] == "Hovercraft"
+
+
+def test_list_events_view_events_permission_sufficient(
+    client, td_user, other_tournament, db
+):
+    db.add(TournamentMembership(
+        user_id=td_user.id,
+        tournament_id=other_tournament.id,
+        positions=["event_supervisor"],
+        status="confirmed",
+    ))
+    db.commit()
+    login(client, "td@test.com", "tdpass")
+    assert client.get(f"/tournaments/{other_tournament.id}/events/").status_code == 200
+
+
+def test_list_events_non_member_gets_404(client, td_user, other_tournament):
+    login(client, "td@test.com", "tdpass")
+    assert client.get(f"/tournaments/{other_tournament.id}/events/").status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Get single
+# ---------------------------------------------------------------------------
+
+def test_get_event(client, td_user, td_tournament):
+    login(client, "td@test.com", "tdpass")
+    created = _make_event(client, td_tournament.id).json()
+    response = client.get(f"/tournaments/{td_tournament.id}/events/{created['id']}/")
+    assert response.status_code == 200
+    assert response.json()["name"] == "Boomilever"
+
+
+def test_get_event_wrong_tournament_404(
+    client, td_user, td_tournament, other_user, other_tournament, db
+):
+    db.add(TournamentMembership(
+        user_id=td_user.id,
+        tournament_id=other_tournament.id,
+        positions=["event_supervisor"],
+        status="confirmed",
+    ))
+    db.commit()
+    login(client, "td@test.com", "tdpass")
+    event = _make_event(client, td_tournament.id).json()
+    assert client.get(
+        f"/tournaments/{other_tournament.id}/events/{event['id']}/"
+    ).status_code == 404
+
+
+def test_get_event_not_found(client, td_user, td_tournament):
+    login(client, "td@test.com", "tdpass")
+    assert client.get(f"/tournaments/{td_tournament.id}/events/9999/").status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# PATCH
+# ---------------------------------------------------------------------------
+
+def test_update_event(client, td_user, td_tournament):
+    login(client, "td@test.com", "tdpass")
+    created = _make_event(client, td_tournament.id).json()
+    response = client.patch(
+        f"/tournaments/{td_tournament.id}/events/{created['id']}/",
+        json={"building": "Science Hall", "room": "204"},
+    )
+    assert response.status_code == 200
+    assert response.json()["building"] == "Science Hall"
+
+
+def test_update_event_volunteer_cannot_patch(
+    client, td_user, other_user, other_tournament, db
+):
+    db.add(TournamentMembership(
+        user_id=td_user.id,
+        tournament_id=other_tournament.id,
+        positions=["event_supervisor"],
+        status="confirmed",
+    ))
+    db.commit()
+    login(client, "other@test.com", "otherpass")
+    event = _make_event(client, other_tournament.id).json()
+    login(client, "td@test.com", "tdpass")
+    assert client.patch(
+        f"/tournaments/{other_tournament.id}/events/{event['id']}/",
+        json={"room": "999"},
+    ).status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# DELETE
+# ---------------------------------------------------------------------------
+
+def test_delete_event(client, td_user, td_tournament):
+    login(client, "td@test.com", "tdpass")
+    created = _make_event(client, td_tournament.id).json()
+    assert client.delete(
+        f"/tournaments/{td_tournament.id}/events/{created['id']}/"
+    ).status_code == 204
+    assert client.get(
+        f"/tournaments/{td_tournament.id}/events/{created['id']}/"
+    ).status_code == 404
+
+
+def test_delete_event_not_found(client, td_user, td_tournament):
+    login(client, "td@test.com", "tdpass")
+    assert client.delete(f"/tournaments/{td_tournament.id}/events/9999/").status_code == 404

--- a/backend/tests/api/test_tournament_memberships.py
+++ b/backend/tests/api/test_tournament_memberships.py
@@ -2,7 +2,7 @@
 import pytest
 from fastapi.testclient import TestClient
 from tests.conftest import login
-from app.models.models import Membership
+from app.models.models import TournamentMembership
 
 
 def _make_user(db, email="alice@example.com"):
@@ -139,7 +139,7 @@ def test_create_membership_non_member_forbidden(client, td_user, other_tournamen
 def test_create_membership_volunteer_member_forbidden(
     client, td_user, other_tournament, db
 ):
-    db.add(Membership(
+    db.add(TournamentMembership(
         user_id=td_user.id,
         tournament_id=other_tournament.id,
         positions=["event_supervisor"],
@@ -180,7 +180,7 @@ def test_list_memberships_filter_by_status(client, td_user, td_tournament, db):
 def test_list_memberships_requires_view_volunteers(
     client, td_user, other_tournament, db
 ):
-    db.add(Membership(
+    db.add(TournamentMembership(
         user_id=td_user.id,
         tournament_id=other_tournament.id,
         positions=["event_supervisor"],

--- a/backend/tests/api/test_tournaments.py
+++ b/backend/tests/api/test_tournaments.py
@@ -3,7 +3,7 @@ import pytest
 from fastapi.testclient import TestClient
 from tests.conftest import login
 from app.core.permissions import DEFAULT_POSITIONS
-from app.models.models import Membership, Tournament
+from app.models.models import TournamentMembership, Tournament
 
 SAMPLE_BLOCKS = [
     {"number": 1, "label": "Block 1", "date": "2025-11-15", "start": "08:00", "end": "09:00"},
@@ -68,7 +68,7 @@ def test_list_my_tournaments_excludes_others(
 def test_list_my_tournaments_includes_volunteer_membership(
     client, td_user, other_tournament, db
 ):
-    db.add(Membership(
+    db.add(TournamentMembership(
         user_id=td_user.id,
         tournament_id=other_tournament.id,
         positions=["event_supervisor"],
@@ -119,12 +119,12 @@ def test_create_tournament_auto_populates_default_positions(client, td_user):
 
 def test_create_tournament_auto_creates_td_membership(client, td_user, db):
     login(client, "td@test.com", "tdpass")
-    response = client.post("/tournaments/", json={"name": "Auto Membership"})
+    response = client.post("/tournaments/", json={"name": "Auto TournamentMembership"})
     assert response.status_code == 201
     tournament_id = response.json()["id"]
-    membership = db.query(Membership).filter(
-        Membership.user_id == td_user.id,
-        Membership.tournament_id == tournament_id,
+    membership = db.query(TournamentMembership).filter(
+        TournamentMembership.user_id == td_user.id,
+        TournamentMembership.tournament_id == tournament_id,
     ).first()
     assert membership is not None
     assert "tournament_director" in membership.positions
@@ -195,7 +195,7 @@ def test_get_tournament_admin_can_access_any(client, admin_user, td_tournament):
 def test_get_tournament_volunteer_member_can_access(
     client, td_user, other_tournament, db
 ):
-    db.add(Membership(
+    db.add(TournamentMembership(
         user_id=td_user.id,
         tournament_id=other_tournament.id,
         positions=["event_supervisor"],
@@ -225,7 +225,7 @@ def test_update_tournament_td_can_patch(client, td_user, td_tournament):
 def test_update_tournament_volunteer_member_cannot_patch(
     client, td_user, other_tournament, db
 ):
-    db.add(Membership(
+    db.add(TournamentMembership(
         user_id=td_user.id,
         tournament_id=other_tournament.id,
         positions=["event_supervisor"],
@@ -283,7 +283,7 @@ def test_delete_tournament_admin_can_delete(client, admin_user, td_tournament):
 def test_delete_tournament_non_owner_member_cannot_delete(
     client, td_user, other_tournament, db
 ):
-    db.add(Membership(
+    db.add(TournamentMembership(
         user_id=td_user.id,
         tournament_id=other_tournament.id,
         positions=["tournament_director"],

--- a/backend/tests/api/test_user_experience.py
+++ b/backend/tests/api/test_user_experience.py
@@ -1,0 +1,290 @@
+"""Tests for /users/me/competition-experience/ and /users/me/volunteer-experience/."""
+from tests.conftest import login
+from app.models.models import UserCompetitionExperience, UserVolunteerExperience
+
+
+# ---------------------------------------------------------------------------
+# POST /users/me/competition-experience/
+# ---------------------------------------------------------------------------
+
+class TestCreateCompetitionExperience:
+    def test_valid_event_and_school(self, client, td_user, event):
+        login(client, "td@test.com", "tdpass")
+        res = client.post("/users/me/competition-experience/", json={
+            "event_id": event.id,
+            "school": "MIT",
+        })
+        assert res.status_code == 201
+        data = res.json()
+        assert data["event_id"] == event.id
+        assert data["school"] == "MIT"
+
+    def test_invalid_event_id_404(self, client, td_user):
+        login(client, "td@test.com", "tdpass")
+        res = client.post("/users/me/competition-experience/", json={
+            "event_id": 9999,
+            "school": "MIT",
+        })
+        assert res.status_code == 404
+
+    def test_unauthenticated_forbidden(self, client, event):
+        res = client.post("/users/me/competition-experience/", json={
+            "event_id": event.id,
+            "school": "MIT",
+        })
+        assert res.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# PATCH /users/me/competition-experience/{id}/
+# ---------------------------------------------------------------------------
+
+class TestUpdateCompetitionExperience:
+    def test_partial_update(self, client, db, td_user, event):
+        entry = UserCompetitionExperience(user_id=td_user.id, event_id=event.id, school="MIT")
+        db.add(entry)
+        db.commit()
+        login(client, "td@test.com", "tdpass")
+        res = client.patch(f"/users/me/competition-experience/{entry.id}/", json={"school": "Caltech"})
+        assert res.status_code == 200
+        data = res.json()
+        assert data["school"] == "Caltech"
+        assert data["event_id"] == event.id  # untouched
+
+    def test_missing_entry_404(self, client, td_user):
+        login(client, "td@test.com", "tdpass")
+        res = client.patch("/users/me/competition-experience/9999/", json={"school": "Caltech"})
+        assert res.status_code == 404
+
+    def test_other_users_entry_404(self, client, db, td_user, other_user, event):
+        entry = UserCompetitionExperience(user_id=other_user.id, event_id=event.id, school="MIT")
+        db.add(entry)
+        db.commit()
+        login(client, "td@test.com", "tdpass")
+        res = client.patch(f"/users/me/competition-experience/{entry.id}/", json={"school": "Caltech"})
+        assert res.status_code == 404
+
+    def test_invalid_event_id_404(self, client, db, td_user, event):
+        entry = UserCompetitionExperience(user_id=td_user.id, event_id=event.id, school="MIT")
+        db.add(entry)
+        db.commit()
+        login(client, "td@test.com", "tdpass")
+        res = client.patch(f"/users/me/competition-experience/{entry.id}/", json={"event_id": 9999})
+        assert res.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /users/me/competition-experience/{id}/
+# ---------------------------------------------------------------------------
+
+class TestDeleteCompetitionExperience:
+    def test_delete_own_entry(self, client, db, td_user, event):
+        entry = UserCompetitionExperience(user_id=td_user.id, event_id=event.id, school="MIT")
+        db.add(entry)
+        db.commit()
+        login(client, "td@test.com", "tdpass")
+        assert client.delete(f"/users/me/competition-experience/{entry.id}/").status_code == 204
+        assert db.get(UserCompetitionExperience, entry.id) is None
+
+    def test_other_users_entry_404(self, client, db, td_user, other_user, event):
+        entry = UserCompetitionExperience(user_id=other_user.id, event_id=event.id, school="MIT")
+        db.add(entry)
+        db.commit()
+        login(client, "td@test.com", "tdpass")
+        assert client.delete(f"/users/me/competition-experience/{entry.id}/").status_code == 404
+        assert db.get(UserCompetitionExperience, entry.id) is not None
+
+    def test_nonexistent_entry_404(self, client, td_user):
+        login(client, "td@test.com", "tdpass")
+        assert client.delete("/users/me/competition-experience/9999/").status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /users/me/volunteer-experience/
+# ---------------------------------------------------------------------------
+
+class TestCreateVolunteerExperience:
+    def test_minimal_fields(self, client, td_user):
+        login(client, "td@test.com", "tdpass")
+        res = client.post("/users/me/volunteer-experience/", json={
+            "tournament_name": "Regionals",
+            "year": 2025,
+            "role": "Event Supervisor",
+        })
+        assert res.status_code == 201
+        data = res.json()
+        assert data["tournament_name"] == "Regionals"
+        assert data["year"] == 2025
+        assert data["role"] == "Event Supervisor"
+        assert data["event_id"] is None
+        assert data["notes"] is None
+
+    def test_with_event_id_no_notes_event(self, client, td_user, event):
+        login(client, "td@test.com", "tdpass")
+        res = client.post("/users/me/volunteer-experience/", json={
+            "tournament_name": "Regionals",
+            "year": 2025,
+            "role": "Event Supervisor",
+            "event_id": event.id,
+        })
+        assert res.status_code == 201
+        assert res.json()["event_id"] == event.id
+
+    def test_with_notes_event_no_event_id(self, client, td_user):
+        login(client, "td@test.com", "tdpass")
+        res = client.post("/users/me/volunteer-experience/", json={
+            "tournament_name": "Regionals",
+            "year": 2025,
+            "role": "Event Supervisor",
+            "notes": {"event": "Custom Event Name"},
+        })
+        assert res.status_code == 201
+        data = res.json()
+        assert data["event_id"] is None
+        assert data["notes"]["event"] == "Custom Event Name"
+
+    def test_event_id_and_notes_event_mutually_exclusive(self, client, td_user, event):
+        login(client, "td@test.com", "tdpass")
+        res = client.post("/users/me/volunteer-experience/", json={
+            "tournament_name": "Regionals",
+            "year": 2025,
+            "role": "Event Supervisor",
+            "event_id": event.id,
+            "notes": {"event": "Custom Event Name"},
+        })
+        assert res.status_code == 422
+
+    def test_notes_other_coexists_with_event_id(self, client, td_user, event):
+        login(client, "td@test.com", "tdpass")
+        res = client.post("/users/me/volunteer-experience/", json={
+            "tournament_name": "Regionals",
+            "year": 2025,
+            "role": "Event Supervisor",
+            "event_id": event.id,
+            "notes": {"other": "Great experience"},
+        })
+        assert res.status_code == 201
+        assert res.json()["notes"]["other"] == "Great experience"
+
+    def test_notes_other_coexists_with_notes_event(self, client, td_user):
+        login(client, "td@test.com", "tdpass")
+        res = client.post("/users/me/volunteer-experience/", json={
+            "tournament_name": "Regionals",
+            "year": 2025,
+            "role": "Event Supervisor",
+            "notes": {"event": "Custom Event Name", "other": "Great experience"},
+        })
+        assert res.status_code == 201
+        data = res.json()
+        assert data["notes"]["event"] == "Custom Event Name"
+        assert data["notes"]["other"] == "Great experience"
+
+    def test_invalid_event_id_404(self, client, td_user):
+        login(client, "td@test.com", "tdpass")
+        res = client.post("/users/me/volunteer-experience/", json={
+            "tournament_name": "Regionals",
+            "year": 2025,
+            "role": "Event Supervisor",
+            "event_id": 9999,
+        })
+        assert res.status_code == 404
+
+    def test_unauthenticated_forbidden(self, client):
+        res = client.post("/users/me/volunteer-experience/", json={
+            "tournament_name": "Regionals",
+            "year": 2025,
+            "role": "Event Supervisor",
+        })
+        assert res.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# PATCH /users/me/volunteer-experience/{id}/
+# ---------------------------------------------------------------------------
+
+class TestUpdateVolunteerExperience:
+    def test_partial_update(self, client, db, td_user):
+        entry = UserVolunteerExperience(
+            user_id=td_user.id, tournament_name="Regionals", year=2025, role="Event Supervisor",
+        )
+        db.add(entry)
+        db.commit()
+        login(client, "td@test.com", "tdpass")
+        res = client.patch(f"/users/me/volunteer-experience/{entry.id}/", json={"role": "Scorer"})
+        assert res.status_code == 200
+        data = res.json()
+        assert data["role"] == "Scorer"
+        assert data["tournament_name"] == "Regionals"  # untouched
+
+    def test_other_users_entry_404(self, client, db, td_user, other_user):
+        entry = UserVolunteerExperience(
+            user_id=other_user.id, tournament_name="Regionals", year=2025, role="Event Supervisor",
+        )
+        db.add(entry)
+        db.commit()
+        login(client, "td@test.com", "tdpass")
+        res = client.patch(f"/users/me/volunteer-experience/{entry.id}/", json={"role": "Scorer"})
+        assert res.status_code == 404
+
+    def test_nonexistent_entry_404(self, client, td_user):
+        login(client, "td@test.com", "tdpass")
+        res = client.patch("/users/me/volunteer-experience/9999/", json={"role": "Scorer"})
+        assert res.status_code == 404
+
+    def test_adding_event_id_to_entry_with_notes_event_rejected(self, client, db, td_user, event):
+        # Entry starts with notes.event set (no event_id) — PATCH only touches
+        # event_id, but the merged post-update state would violate exclusivity.
+        entry = UserVolunteerExperience(
+            user_id=td_user.id, tournament_name="Regionals", year=2025, role="Event Supervisor",
+            notes={"event": "Custom Event Name"},
+        )
+        db.add(entry)
+        db.commit()
+        login(client, "td@test.com", "tdpass")
+        res = client.patch(f"/users/me/volunteer-experience/{entry.id}/", json={"event_id": event.id})
+        assert res.status_code == 422
+
+    def test_adding_notes_event_to_entry_with_event_id_rejected(self, client, db, td_user, event):
+        # Reverse case — entry has event_id set, PATCH only touches notes.
+        entry = UserVolunteerExperience(
+            user_id=td_user.id, tournament_name="Regionals", year=2025, role="Event Supervisor",
+            event_id=event.id,
+        )
+        db.add(entry)
+        db.commit()
+        login(client, "td@test.com", "tdpass")
+        res = client.patch(
+            f"/users/me/volunteer-experience/{entry.id}/",
+            json={"notes": {"event": "Custom Event Name"}},
+        )
+        assert res.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# DELETE /users/me/volunteer-experience/{id}/
+# ---------------------------------------------------------------------------
+
+class TestDeleteVolunteerExperience:
+    def test_delete_own_entry(self, client, db, td_user):
+        entry = UserVolunteerExperience(
+            user_id=td_user.id, tournament_name="Regionals", year=2025, role="Event Supervisor",
+        )
+        db.add(entry)
+        db.commit()
+        login(client, "td@test.com", "tdpass")
+        assert client.delete(f"/users/me/volunteer-experience/{entry.id}/").status_code == 204
+        assert db.get(UserVolunteerExperience, entry.id) is None
+
+    def test_other_users_entry_404(self, client, db, td_user, other_user):
+        entry = UserVolunteerExperience(
+            user_id=other_user.id, tournament_name="Regionals", year=2025, role="Event Supervisor",
+        )
+        db.add(entry)
+        db.commit()
+        login(client, "td@test.com", "tdpass")
+        assert client.delete(f"/users/me/volunteer-experience/{entry.id}/").status_code == 404
+        assert db.get(UserVolunteerExperience, entry.id) is not None
+
+    def test_nonexistent_entry_404(self, client, td_user):
+        login(client, "td@test.com", "tdpass")
+        assert client.delete("/users/me/volunteer-experience/9999/").status_code == 404

--- a/backend/tests/api/test_users.py
+++ b/backend/tests/api/test_users.py
@@ -1,7 +1,7 @@
-"""Tests for /admin/users, /users/me, and /tournaments/{id}/users endpoints."""
+"""Tests for /admin/users and /users/me endpoints."""
 from tests.conftest import login
 from app.core.auth import hash_password
-from app.models.models import Membership, User
+from app.models.models import User
 
 
 VALID_PHONE = "9495551234"
@@ -189,7 +189,7 @@ class TestMissingProfileFields:
     def test_fresh_user_has_missing_fields(self, client, td_user):
         # td_user has no profile data — phone and student_status should be missing
         login(client, "td@test.com", "tdpass")
-        missing = client.get("/auth/me/").json()["missing_profile_fields"]
+        missing = client.get("/users/me/").json()["missing_profile_fields"]
         assert "phone" in missing
         assert "student_status" in missing
 
@@ -197,36 +197,40 @@ class TestMissingProfileFields:
         login(client, "td@test.com", "tdpass")
         client.patch("/users/me/", json={
             "phone": VALID_PHONE,
+            "date_of_birth": "2000-01-01",
+            "pronouns": "she/her",
             "student_status": "Non-Student",
             "employer": "Acme Corp",
-            "competition_exp": "10 years",
-            "volunteering_exp": "5 years",
+            "has_competition_experience": False,
+            "has_volunteer_experience": False,
             "shirt_size": "M",
             "dietary_restriction": "None",
         })
-        assert client.get("/auth/me/").json()["missing_profile_fields"] == []
+        assert client.get("/users/me/").json()["missing_profile_fields"] == []
 
     def test_student_complete_profile(self, client, td_user):
         login(client, "td@test.com", "tdpass")
         client.patch("/users/me/", json={
             "phone": VALID_PHONE,
+            "date_of_birth": "2000-01-01",
+            "pronouns": "she/her",
             "student_status": "Undergraduate",
             "university": "MIT",
             "major": "CS",
             "year_level": 2,
             "graduation_year": 2027,
-            "competition_exp": "3 years",
-            "volunteering_exp": "2 years",
+            "has_competition_experience": False,
+            "has_volunteer_experience": False,
             "shirt_size": "L",
             "dietary_restriction": "None",
         })
-        assert client.get("/auth/me/").json()["missing_profile_fields"] == []
+        assert client.get("/users/me/").json()["missing_profile_fields"] == []
 
     def test_student_missing_school_fields(self, client, td_user):
         # student_status answered but university/major not filled in yet
         login(client, "td@test.com", "tdpass")
         client.patch("/users/me/", json={"phone": VALID_PHONE, "student_status": "Undergraduate"})
-        missing = client.get("/auth/me/").json()["missing_profile_fields"]
+        missing = client.get("/users/me/").json()["missing_profile_fields"]
         assert "university" in missing
         assert "major" in missing
 
@@ -234,84 +238,15 @@ class TestMissingProfileFields:
         login(client, "td@test.com", "tdpass")
         client.patch("/users/me/", json={
             "phone": VALID_PHONE,
+            "date_of_birth": "2000-01-01",
+            "pronouns": "she/her",
             "student_status": "Non-Student",
             "employer": "Acme Corp",
-            "competition_exp": "10 years",
-            "volunteering_exp": "5 years",
+            "has_competition_experience": False,
+            "has_volunteer_experience": False,
             "shirt_size": "M",
             "dietary_restriction": "None",
         })
-        missing = client.get("/auth/me/").json()["missing_profile_fields"]
+        missing = client.get("/users/me/").json()["missing_profile_fields"]
         assert "university" not in missing
         assert "major" not in missing
-
-
-# ---------------------------------------------------------------------------
-# GET /tournaments/{id}/users/{user_id}/ — manage_volunteers or manage_tournament
-# ---------------------------------------------------------------------------
-
-class TestTournamentUser:
-    def test_td_can_access_member(self, client, admin_user, td_user, td_tournament, db):
-        alice = _db_user(db)
-        db.add(Membership(
-            user_id=alice.id,
-            tournament_id=td_tournament.id,
-            positions=["event_supervisor"],
-            status="confirmed",
-        ))
-        db.commit()
-        login(client, "td@test.com", "tdpass")
-        res = client.get(f"/tournaments/{td_tournament.id}/users/{alice.id}/")
-        assert res.status_code == 200
-        assert res.json()["email"] == "alice@example.com"
-
-    def test_volunteer_coordinator_can_access(
-        self, client, admin_user, td_user, other_tournament, db
-    ):
-        db.add(Membership(
-            user_id=td_user.id,
-            tournament_id=other_tournament.id,
-            positions=["volunteer_coordinator"],
-            status="confirmed",
-        ))
-        alice = _db_user(db)
-        db.add(Membership(
-            user_id=alice.id,
-            tournament_id=other_tournament.id,
-            positions=["event_supervisor"],
-            status="confirmed",
-        ))
-        db.commit()
-        login(client, "td@test.com", "tdpass")
-        assert client.get(
-            f"/tournaments/{other_tournament.id}/users/{alice.id}/"
-        ).status_code == 200
-
-    def test_event_supervisor_forbidden(
-        self, client, td_user, other_tournament, admin_user, db
-    ):
-        db.add(Membership(
-            user_id=td_user.id,
-            tournament_id=other_tournament.id,
-            positions=["event_supervisor"],
-            status="confirmed",
-        ))
-        alice = _db_user(db)
-        db.add(Membership(
-            user_id=alice.id,
-            tournament_id=other_tournament.id,
-            positions=["event_supervisor"],
-            status="confirmed",
-        ))
-        db.commit()
-        login(client, "td@test.com", "tdpass")
-        assert client.get(
-            f"/tournaments/{other_tournament.id}/users/{alice.id}/"
-        ).status_code == 403
-
-    def test_non_member_returns_404(self, client, admin_user, td_user, td_tournament, db):
-        alice = _db_user(db)
-        login(client, "td@test.com", "tdpass")
-        assert client.get(
-            f"/tournaments/{td_tournament.id}/users/{alice.id}/"
-        ).status_code == 404

--- a/backend/tests/api/test_users.py
+++ b/backend/tests/api/test_users.py
@@ -1,7 +1,9 @@
 """Tests for /admin/users and /users/me endpoints."""
 from tests.conftest import login
 from app.core.auth import hash_password
-from app.models.models import User
+from app.models.models import (
+    User, Event, EventCategory, UserCompetitionExperience, UserVolunteerExperience,
+)
 
 
 VALID_PHONE = "9495551234"
@@ -155,7 +157,7 @@ class TestAdminDeleteUser:
 
 
 # ---------------------------------------------------------------------------
-# GET /users/me/ — authenticated user's own full profile
+# GET /users/me/ (default, no ?full) — slim shape, folded in from old /auth/me/
 # ---------------------------------------------------------------------------
 
 class TestGetMe:
@@ -165,10 +167,67 @@ class TestGetMe:
         assert res.status_code == 200
         data = res.json()
         assert data["email"] == "td@test.com"
-        assert "missing_profile_fields" in data
+        assert "is_profile_complete" in data
+        # Slim shape — full-only fields must not be present.
+        assert "missing_profile_fields" not in data
+        assert "competition_experience" not in data
 
     def test_unauthenticated_forbidden(self, client):
         assert client.get("/users/me/").status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /users/me/?full=true — full shape with experience lists eagerly loaded
+# ---------------------------------------------------------------------------
+
+class TestGetMeFull:
+    def test_returns_full_shape(self, client, td_user):
+        login(client, "td@test.com", "tdpass")
+        res = client.get("/users/me/?full=true")
+        assert res.status_code == 200
+        data = res.json()
+        assert data["email"] == "td@test.com"
+        assert "missing_profile_fields" in data
+        assert "competition_experience" in data
+        assert "volunteer_experience" in data
+        # Full shape — slim-only field must not be present.
+        assert "is_profile_complete" not in data
+
+    def test_unauthenticated_forbidden(self, client):
+        assert client.get("/users/me/?full=true").status_code == 401
+
+    def test_competition_and_volunteer_experience_populated(self, client, td_user, db):
+        category = EventCategory(name="Chemistry")
+        db.add(category)
+        db.commit()
+        event = Event(name="Boomilever", category_id=category.id)
+        db.add(event)
+        db.commit()
+
+        db.add(UserCompetitionExperience(user_id=td_user.id, event_id=event.id, school="MIT"))
+        db.add(UserVolunteerExperience(
+            user_id=td_user.id, event_id=event.id,
+            tournament_name="Regionals", year=2025, role="Event Supervisor",
+        ))
+        db.commit()
+
+        login(client, "td@test.com", "tdpass")
+        data = client.get("/users/me/?full=true").json()
+
+        assert len(data["competition_experience"]) == 1
+        assert data["competition_experience"][0]["school"] == "MIT"
+        assert data["competition_experience"][0]["event_id"] == event.id
+
+        assert len(data["volunteer_experience"]) == 1
+        assert data["volunteer_experience"][0]["tournament_name"] == "Regionals"
+        assert data["volunteer_experience"][0]["year"] == 2025
+        assert data["volunteer_experience"][0]["role"] == "Event Supervisor"
+
+    def test_no_experience_rows_returns_empty_lists(self, client, td_user):
+        login(client, "td@test.com", "tdpass")
+        data = client.get("/users/me/?full=true").json()
+        assert data["competition_experience"] == []
+        assert data["volunteer_experience"] == []
 
 
 # ---------------------------------------------------------------------------
@@ -186,7 +245,7 @@ class TestUpdateMe:
         # exclude_unset=True — omitted fields must not overwrite existing data
         login(client, "td@test.com", "tdpass")
         client.patch("/users/me/", json={"first_name": "Updated"})
-        assert client.get("/auth/me/").json()["last_name"] == "User"
+        assert client.get("/users/me/").json()["last_name"] == "User"
 
     def test_can_update_email(self, client, td_user):
         login(client, "td@test.com", "tdpass")
@@ -259,7 +318,7 @@ class TestMissingProfileFields:
     def test_fresh_user_has_missing_fields(self, client, td_user):
         # td_user has no profile data — phone and student_status should be missing
         login(client, "td@test.com", "tdpass")
-        missing = client.get("/users/me/").json()["missing_profile_fields"]
+        missing = client.get("/users/me/?full=true").json()["missing_profile_fields"]
         assert "phone" in missing
         assert "student_status" in missing
 
@@ -276,7 +335,7 @@ class TestMissingProfileFields:
             "shirt_size": "M",
             "dietary_restriction": "None",
         })
-        assert client.get("/users/me/").json()["missing_profile_fields"] == []
+        assert client.get("/users/me/?full=true").json()["missing_profile_fields"] == []
 
     def test_student_complete_profile(self, client, td_user):
         login(client, "td@test.com", "tdpass")
@@ -294,13 +353,13 @@ class TestMissingProfileFields:
             "shirt_size": "L",
             "dietary_restriction": "None",
         })
-        assert client.get("/users/me/").json()["missing_profile_fields"] == []
+        assert client.get("/users/me/?full=true").json()["missing_profile_fields"] == []
 
     def test_student_missing_school_fields(self, client, td_user):
         # student_status answered but university/major not filled in yet
         login(client, "td@test.com", "tdpass")
         client.patch("/users/me/", json={"phone": VALID_PHONE, "student_status": "Undergraduate"})
-        missing = client.get("/users/me/").json()["missing_profile_fields"]
+        missing = client.get("/users/me/?full=true").json()["missing_profile_fields"]
         assert "university" in missing
         assert "major" in missing
 
@@ -317,19 +376,19 @@ class TestMissingProfileFields:
             "shirt_size": "M",
             "dietary_restriction": "None",
         })
-        missing = client.get("/users/me/").json()["missing_profile_fields"]
+        missing = client.get("/users/me/?full=true").json()["missing_profile_fields"]
         assert "university" not in missing
         assert "major" not in missing
 
 
 # ---------------------------------------------------------------------------
-# is_profile_complete — boolean field on UserMeSlimResponse (GET /auth/me/)
+# is_profile_complete — boolean field on UserMeSlimResponse (GET /users/me/)
 # ---------------------------------------------------------------------------
 
 class TestIsProfileComplete:
     def test_fresh_user_is_not_complete(self, client, td_user):
         login(client, "td@test.com", "tdpass")
-        assert client.get("/auth/me/").json()["is_profile_complete"] is False
+        assert client.get("/users/me/").json()["is_profile_complete"] is False
 
     def test_non_student_complete_profile(self, client, td_user):
         login(client, "td@test.com", "tdpass")
@@ -344,7 +403,7 @@ class TestIsProfileComplete:
             "shirt_size": "M",
             "dietary_restriction": "None",
         })
-        assert client.get("/auth/me/").json()["is_profile_complete"] is True
+        assert client.get("/users/me/").json()["is_profile_complete"] is True
 
     def test_student_complete_profile(self, client, td_user):
         login(client, "td@test.com", "tdpass")
@@ -362,15 +421,15 @@ class TestIsProfileComplete:
             "shirt_size": "L",
             "dietary_restriction": "None",
         })
-        assert client.get("/auth/me/").json()["is_profile_complete"] is True
+        assert client.get("/users/me/").json()["is_profile_complete"] is True
 
     def test_student_missing_school_fields_is_not_complete(self, client, td_user):
         login(client, "td@test.com", "tdpass")
         client.patch("/users/me/", json={"phone": VALID_PHONE, "student_status": "Undergraduate"})
-        assert client.get("/auth/me/").json()["is_profile_complete"] is False
+        assert client.get("/users/me/").json()["is_profile_complete"] is False
 
     def test_partial_update_does_not_flip_to_complete(self, client, td_user):
         # Only phone answered — plenty of other required fields still missing.
         login(client, "td@test.com", "tdpass")
         client.patch("/users/me/", json={"phone": VALID_PHONE})
-        assert client.get("/auth/me/").json()["is_profile_complete"] is False
+        assert client.get("/users/me/").json()["is_profile_complete"] is False

--- a/backend/tests/api/test_users.py
+++ b/backend/tests/api/test_users.py
@@ -62,6 +62,9 @@ class TestAdminGetUser:
         login(client, "admin@test.com", "adminpass")
         assert client.get("/admin/users/9999/").status_code == 404
 
+    def test_unauthenticated_forbidden(self, client):
+        assert client.get("/admin/users/1/").status_code == 401
+
 
 # ---------------------------------------------------------------------------
 # GET /admin/users/by-email/{email}/ — admin only
@@ -76,6 +79,15 @@ class TestAdminGetUserByEmail:
     def test_not_found(self, client, admin_user):
         login(client, "admin@test.com", "adminpass")
         assert client.get("/admin/users/by-email/nobody@example.com/").status_code == 404
+
+    def test_non_admin_forbidden(self, client, td_user, db):
+        _db_user(db)
+        login(client, "td@test.com", "tdpass")
+        assert client.get("/admin/users/by-email/alice@example.com/").status_code == 403
+
+    def test_unauthenticated_forbidden(self, client, db):
+        _db_user(db)
+        assert client.get("/admin/users/by-email/alice@example.com/").status_code == 401
 
 
 # ---------------------------------------------------------------------------
@@ -134,6 +146,30 @@ class TestAdminDeleteUser:
         login(client, "td@test.com", "tdpass")
         assert client.delete("/admin/users/1/").status_code == 403
 
+    def test_not_found(self, client, admin_user):
+        login(client, "admin@test.com", "adminpass")
+        assert client.delete("/admin/users/9999/").status_code == 404
+
+    def test_unauthenticated_forbidden(self, client):
+        assert client.delete("/admin/users/1/").status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /users/me/ — authenticated user's own full profile
+# ---------------------------------------------------------------------------
+
+class TestGetMe:
+    def test_returns_current_user(self, client, td_user):
+        login(client, "td@test.com", "tdpass")
+        res = client.get("/users/me/")
+        assert res.status_code == 200
+        data = res.json()
+        assert data["email"] == "td@test.com"
+        assert "missing_profile_fields" in data
+
+    def test_unauthenticated_forbidden(self, client):
+        assert client.get("/users/me/").status_code == 401
+
 
 # ---------------------------------------------------------------------------
 # PATCH /users/me/ — authenticated user updates own profile
@@ -161,6 +197,40 @@ class TestUpdateMe:
     def test_duplicate_email_rejected(self, client, td_user, admin_user):
         login(client, "td@test.com", "tdpass")
         assert client.patch("/users/me/", json={"email": "admin@test.com"}).status_code == 409
+
+    def test_duplicate_email_case_insensitive_rejected(self, client, td_user, admin_user):
+        login(client, "td@test.com", "tdpass")
+        assert client.patch("/users/me/", json={"email": "ADMIN@TEST.COM"}).status_code == 409
+
+    def test_same_email_unchanged_not_rejected(self, client, td_user):
+        # Re-submitting your own current email should not conflict with yourself.
+        login(client, "td@test.com", "tdpass")
+        res = client.patch("/users/me/", json={"email": "td@test.com", "first_name": "Still TD"})
+        assert res.status_code == 200
+        assert res.json()["email"] == "td@test.com"
+
+    def test_null_clears_optional_field(self, client, td_user):
+        login(client, "td@test.com", "tdpass")
+        client.patch("/users/me/", json={"pronouns": "she/her"})
+        res = client.patch("/users/me/", json={"pronouns": None})
+        assert res.status_code == 200
+        assert res.json()["pronouns"] is None
+
+    def test_null_first_name_rejected(self, client, td_user):
+        login(client, "td@test.com", "tdpass")
+        assert client.patch("/users/me/", json={"first_name": None}).status_code == 422
+
+    def test_null_last_name_rejected(self, client, td_user):
+        login(client, "td@test.com", "tdpass")
+        assert client.patch("/users/me/", json={"last_name": None}).status_code == 422
+
+    def test_null_email_rejected(self, client, td_user):
+        login(client, "td@test.com", "tdpass")
+        assert client.patch("/users/me/", json={"email": None}).status_code == 422
+
+    def test_null_phone_rejected(self, client, td_user):
+        login(client, "td@test.com", "tdpass")
+        assert client.patch("/users/me/", json={"phone": None}).status_code == 422
 
     def test_invalid_email_rejected(self, client, td_user):
         login(client, "td@test.com", "tdpass")

--- a/backend/tests/api/test_users.py
+++ b/backend/tests/api/test_users.py
@@ -250,3 +250,57 @@ class TestMissingProfileFields:
         missing = client.get("/users/me/").json()["missing_profile_fields"]
         assert "university" not in missing
         assert "major" not in missing
+
+
+# ---------------------------------------------------------------------------
+# is_profile_complete — boolean field on UserMeSlimResponse (GET /auth/me/)
+# ---------------------------------------------------------------------------
+
+class TestIsProfileComplete:
+    def test_fresh_user_is_not_complete(self, client, td_user):
+        login(client, "td@test.com", "tdpass")
+        assert client.get("/auth/me/").json()["is_profile_complete"] is False
+
+    def test_non_student_complete_profile(self, client, td_user):
+        login(client, "td@test.com", "tdpass")
+        client.patch("/users/me/", json={
+            "phone": VALID_PHONE,
+            "date_of_birth": "2000-01-01",
+            "pronouns": "she/her",
+            "student_status": "Non-Student",
+            "employer": "Acme Corp",
+            "has_competition_experience": False,
+            "has_volunteer_experience": False,
+            "shirt_size": "M",
+            "dietary_restriction": "None",
+        })
+        assert client.get("/auth/me/").json()["is_profile_complete"] is True
+
+    def test_student_complete_profile(self, client, td_user):
+        login(client, "td@test.com", "tdpass")
+        client.patch("/users/me/", json={
+            "phone": VALID_PHONE,
+            "date_of_birth": "2000-01-01",
+            "pronouns": "she/her",
+            "student_status": "Undergraduate",
+            "university": "MIT",
+            "major": "CS",
+            "year_level": 2,
+            "graduation_year": 2027,
+            "has_competition_experience": False,
+            "has_volunteer_experience": False,
+            "shirt_size": "L",
+            "dietary_restriction": "None",
+        })
+        assert client.get("/auth/me/").json()["is_profile_complete"] is True
+
+    def test_student_missing_school_fields_is_not_complete(self, client, td_user):
+        login(client, "td@test.com", "tdpass")
+        client.patch("/users/me/", json={"phone": VALID_PHONE, "student_status": "Undergraduate"})
+        assert client.get("/auth/me/").json()["is_profile_complete"] is False
+
+    def test_partial_update_does_not_flip_to_complete(self, client, td_user):
+        # Only phone answered — plenty of other required fields still missing.
+        login(client, "td@test.com", "tdpass")
+        client.patch("/users/me/", json={"phone": VALID_PHONE})
+        assert client.get("/auth/me/").json()["is_profile_complete"] is False

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,7 +1,11 @@
 """
 Shared pytest fixtures.
 
-Uses an in-memory SQLite DB for all tests — fast, isolated, no cleanup needed.
+Uses a dedicated Postgres database ("nexus_test", on the same Docker Postgres
+container as dev) for all tests — real Postgres semantics (savepoints, FK
+enforcement) so behavior matches prod, with a separate DB so a rollback bug
+can never touch real dev data. Each test runs inside an outer transaction
+that's rolled back at teardown, so no cleanup is needed between tests.
 The Google Sheets and Forms services are mocked so tests never hit the real API.
 
 Fixture hierarchy:
@@ -19,7 +23,7 @@ os.environ.setdefault("APP_ENV", "development")
 os.environ.setdefault("API_KEY", "")
 
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine, event
+from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 from unittest.mock import MagicMock
 
@@ -30,7 +34,7 @@ from app.services.sheets_service import SheetsService
 from app.services.forms_service import FormsService
 from app.core.auth import hash_password
 from app.core.permissions import DEFAULT_POSITIONS
-from app.models.models import Membership, Tournament, User
+from app.models.models import TournamentMembership, Tournament, User
 from app.schemas.sheet_config import (
     FormQuestionOption,
     MappedHeader,
@@ -39,18 +43,10 @@ from app.schemas.sheet_config import (
     SheetValidateResponse,
 )
 
-test_engine = create_engine(
-    "sqlite:///:memory:",
-    connect_args={"check_same_thread": False},
-    echo=False,
+TEST_DATABASE_URL = os.environ.get(
+    "TEST_DATABASE_URL", "postgresql://nexus:nexus@127.0.0.1:5432/nexus_test"
 )
-
-
-@event.listens_for(test_engine, "connect")
-def set_sqlite_pragma(dbapi_connection, connection_record):
-    cursor = dbapi_connection.cursor()
-    cursor.execute("PRAGMA foreign_keys=ON")
-    cursor.close()
+test_engine = create_engine(TEST_DATABASE_URL, echo=False)
 
 
 @pytest.fixture(scope="function")
@@ -58,7 +54,10 @@ def db():
     connection = test_engine.connect()
     transaction = connection.begin()
     Base.metadata.create_all(bind=connection)
-    session = Session(bind=connection)
+    # create_savepoint: session.commit()/rollback() operate on a nested SAVEPOINT,
+    # not the outer transaction — so a mid-test rollback (e.g. a caught IntegrityError)
+    # only undoes that one unit of work, not everything committed earlier in the test.
+    session = Session(bind=connection, join_transaction_mode="create_savepoint")
     try:
         yield session
     finally:
@@ -134,7 +133,7 @@ def td_tournament(db, td_user):
     )
     db.add(tournament)
     db.flush()
-    db.add(Membership(
+    db.add(TournamentMembership(
         user_id=td_user.id,
         tournament_id=tournament.id,
         positions=["tournament_director"],
@@ -155,7 +154,7 @@ def other_tournament(db, other_user):
     )
     db.add(tournament)
     db.flush()
-    db.add(Membership(
+    db.add(TournamentMembership(
         user_id=other_user.id,
         tournament_id=tournament.id,
         positions=["tournament_director"],

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -34,7 +34,7 @@ from app.services.sheets_service import SheetsService
 from app.services.forms_service import FormsService
 from app.core.auth import hash_password
 from app.core.permissions import DEFAULT_POSITIONS
-from app.models.models import TournamentMembership, Tournament, User
+from app.models.models import TournamentMembership, Tournament, User, Event, EventCategory
 from app.schemas.sheet_config import (
     FormQuestionOption,
     MappedHeader,
@@ -163,6 +163,42 @@ def other_tournament(db, other_user):
     db.commit()
     db.refresh(tournament)
     return tournament
+
+
+# ---------------------------------------------------------------------------
+# Event / EventCategory fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def event_category_factory(db):
+    def _make(name="Chemistry"):
+        category = EventCategory(name=name)
+        db.add(category)
+        db.commit()
+        db.refresh(category)
+        return category
+    return _make
+
+
+@pytest.fixture
+def event_category(event_category_factory):
+    return event_category_factory()
+
+
+@pytest.fixture
+def event_factory(db):
+    def _make(category, name="Boomilever"):
+        event = Event(name=name, category_id=category.id)
+        db.add(event)
+        db.commit()
+        db.refresh(event)
+        return event
+    return _make
+
+
+@pytest.fixture
+def event(event_factory, event_category):
+    return event_factory(event_category)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/services/test_sync_service.py
+++ b/backend/tests/services/test_sync_service.py
@@ -407,11 +407,11 @@ def test_process_cell_string_parse_time_range_rule():
     assert result == [{"date": "2026-02-14", "start": "07:00", "end": "17:00"}]
 
 
-def test_process_cell_phone_formats_us_number():
+def test_process_cell_phone_normalizes_to_digits():
     t = _make_tournament(NATS_BLOCKS)
     mapping = {"field": "phone", "type": "string"}
-    assert _process_cell("9495551234", mapping, t) == "(949) 555-1234"
-    assert _process_cell("+1 (949) 555-1234", mapping, t) == "(949) 555-1234"
+    assert _process_cell("9495551234", mapping, t) == "9495551234"
+    assert _process_cell("+1 (949) 555-1234", mapping, t) == "9495551234"
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/app/(auth)/sign-up/page.tsx
+++ b/frontend/app/(auth)/sign-up/page.tsx
@@ -6,9 +6,10 @@ import {
   STUDENT_STATUS, SHIRT_SIZE, UserSlim, usersApi 
 } from "@/lib/api"
 import { useRouter } from "next/navigation"
-import { checkPassword, formatPhone, validateEmail, validatePassword, validatePhone } from "@/lib/auth"
+import { checkPassword, formatPhone, validateEmail, validatePassword, validatePhone, validateDateOfBirth } from "@/lib/auth"
 import { IconArrowLeft, IconCheckCircle, IconXCircle } from "@/components/ui/Icons"
 import { Input } from "@/components/ui/Input"
+import { Combobox } from "@/components/ui/Combobox"
 import { Button } from "@/components/ui/Button"
 import { Select } from "@/components/ui/Select"
 import { RadioGroup } from "@/components/ui/RadioGroup"
@@ -32,18 +33,22 @@ function clearCookie() {
 
 const STATE = {
   ACCOUNT: 1,
-  STUDENT_STATUS: 2,
-  UNIVERSITY: 3,
-  EMPLOYER: 4,
-  COMPETED_BEFORE: 5,
-  COMPETITION_EXP: 6,
-  VOLUNTEERED_BEFORE: 7,
-  VOLUNTEERING_EXP: 8,
-  SHIRT_SIZE: 9,
-  DIETARY_RESTRICTIONS: 10,
-  DIETARY_TEXT: 11,
-  COMPLETE: 12,
+  DATE_OF_BIRTH: 2,
+  PRONOUNS: 3,
+  STUDENT_STATUS: 4,
+  UNIVERSITY: 5,
+  EMPLOYER: 6,
+  COMPETED_BEFORE: 7,
+  COMPETITION_EXP: 8,
+  VOLUNTEERED_BEFORE: 9,
+  VOLUNTEERING_EXP: 10,
+  SHIRT_SIZE: 11,
+  DIETARY_RESTRICTIONS: 12,
+  DIETARY_TEXT: 13,
+  COMPLETE: 14,
 } as const
+
+const COMMON_PRONOUNS = ["she/her", "he/him", "they/them", "she/they", "he/they", "any pronouns"]
 
 export default function SignUpPage() {
   // ── Sign-up step states ──────────────────────────────────────────────────
@@ -89,6 +94,9 @@ export default function SignUpPage() {
   const [showVerifyModal, setShowVerifyModal] = useState(false)
 
   const [profileData, setProfileData] = useState<{
+    date_of_birth?: string
+    pronouns?: string
+
     student_status?: STUDENT_STATUS
     university?: string
     major?: string
@@ -120,6 +128,8 @@ export default function SignUpPage() {
     confirm_password?: string
     form1?: string
 
+    date_of_birth?: string
+    pronouns?: string
     student_status?: string
     university?: string
     major?: string
@@ -139,7 +149,7 @@ export default function SignUpPage() {
     usersApi.me().then(user => {
       if (document.cookie.includes("inSignUpFlow")) {
         setUser(user)
-        setState(STATE.STUDENT_STATUS)
+        setState(STATE.DATE_OF_BIRTH)
       } else {
         router.push('/dashboard')
       }
@@ -181,7 +191,7 @@ export default function SignUpPage() {
 
       authApi.sendEmailVerification().then(() => {
         setShowVerifyModal(true)
-      }).catch(() => {}).finally(() => setState(STATE.STUDENT_STATUS))
+      }).catch(() => {}).finally(() => setState(STATE.DATE_OF_BIRTH))
     } catch (error: unknown) {
       if (error instanceof ApiError) {
         setErrors({ form1: error.message })
@@ -225,6 +235,19 @@ export default function SignUpPage() {
 
     for (const key of Object.keys(cleaned)) {
       if (cleaned[key] === "") cleaned[key] = undefined
+    }
+
+    const dobErr = cleaned.date_of_birth ? validateDateOfBirth(cleaned.date_of_birth as string) : null
+    if (dobErr) {
+      setErrors(er => ({ ...er, date_of_birth: dobErr }))
+      setLoading(false)
+      return
+    }
+
+    if (cleaned.pronouns !== undefined && !(cleaned.pronouns as string).trim()) {
+      setErrors(er => ({ ...er, pronouns: "Cannot be empty." }))
+      setLoading(false)
+      return
     }
 
     if (cleaned.graduation_year && ((cleaned.graduation_year as number) < 1000 || (cleaned.graduation_year as number) > 9999)) {
@@ -412,7 +435,7 @@ export default function SignUpPage() {
         </section>
       )}
 
-      {state >= STATE.STUDENT_STATUS && (
+      {state >= STATE.DATE_OF_BIRTH && (
         <section style={{ maxWidth: '600px', width: '100%', margin: '20px 0px'}}>
           {showVerifyModal && <VerifyModal />}
 
@@ -435,28 +458,83 @@ export default function SignUpPage() {
 
           <form onSubmit={handleProfileSubmit} noValidate>
             <ProfileQuestion
-              question="What is your student status?"
-              onSkip={() => setState(STATE.STUDENT_STATUS + 3)}
-              isActive={state === STATE.STUDENT_STATUS}
-            ><Select
-                value={profileData.student_status ?? ''}
-                onChange={v => {
-                  setProfileData(d => ({...d, student_status: v as STUDENT_STATUS}))
-                  if (state >= (STATE.STUDENT_STATUS + 3)) return
-                  if (v === 'Undergraduate' || v === 'Graduate') {
-                    setState(STATE.UNIVERSITY)
-                  } else if (v === 'Non-Student') {
-                    setState(STATE.EMPLOYER)
-                  }
-                }}
-                options={[
-                  { value: "Undergraduate", label: "Undergraduate" },
-                  { value: "Graduate", label: "Graduate" },
-                  { value: "Non-Student", label: "Non-Student" }
-                ]}
-                fullWidth
+              question="What is your date of birth?"
+              onSkip={() => setState(STATE.PRONOUNS)}
+              onNext={() => {
+                const err = validateDateOfBirth(profileData.date_of_birth ?? '')
+                if (err) {
+                  setErrors(er => ({ ...er, date_of_birth: err }))
+                  return
+                }
+                setState(STATE.PRONOUNS)
+              }}
+              isActive={state === STATE.DATE_OF_BIRTH}
+            ><Input
+                  type="date"
+                  value={profileData.date_of_birth ?? ''}
+                  onChange={e => {
+                    setProfileData(d => ({ ...d, date_of_birth: e.target.value }))
+                    setErrors(er => ({ ...er, date_of_birth: undefined }))
+                  }}
+                  error={errors.date_of_birth}
+                  fullWidth
               />
             </ProfileQuestion>
+
+            {state >= STATE.PRONOUNS && (
+              <ProfileQuestion
+                question="What are your pronouns?"
+                onSkip={() => setState(STATE.STUDENT_STATUS)}
+                onNext={() => {
+                  if (!profileData.pronouns?.trim()) {
+                    setErrors(er => ({ ...er, pronouns: "Cannot be empty." }))
+                    return
+                  }
+                  setState(STATE.STUDENT_STATUS)
+                }}
+                isActive={state === STATE.PRONOUNS}
+              >
+                <Combobox
+                  options={COMMON_PRONOUNS}
+                  getId={p => p}
+                  getLabel={p => p}
+                  value={profileData.pronouns ?? ''}
+                  allowFreeText
+                  placeholder="Type your pronouns..."
+                  error={errors.pronouns}
+                  onChange={(text) => {
+                    setProfileData(d => ({ ...d, pronouns: text }))
+                    setErrors(er => ({ ...er, pronouns: undefined }))
+                  }}
+                />
+              </ProfileQuestion>
+            )}
+            
+            { state >= STATE.STUDENT_STATUS && (
+              <ProfileQuestion
+                question="What is your student status?"
+                onSkip={() => setState(STATE.STUDENT_STATUS + 3)}
+                isActive={state === STATE.STUDENT_STATUS}
+              ><Select
+                  value={profileData.student_status ?? ''}
+                  onChange={v => {
+                    setProfileData(d => ({...d, student_status: v as STUDENT_STATUS}))
+                    if (state >= (STATE.STUDENT_STATUS + 3)) return
+                    if (v === 'Undergraduate' || v === 'Graduate') {
+                      setState(STATE.UNIVERSITY)
+                    } else if (v === 'Non-Student') {
+                      setState(STATE.EMPLOYER)
+                    }
+                  }}
+                  options={[
+                    { value: "Undergraduate", label: "Undergraduate" },
+                    { value: "Graduate", label: "Graduate" },
+                    { value: "Non-Student", label: "Non-Student" }
+                  ]}
+                  fullWidth
+                />
+              </ProfileQuestion>
+            )}
 
             { state >= STATE.UNIVERSITY && (profileData.student_status === "Undergraduate" || profileData.student_status === "Graduate") && (
               <div>

--- a/frontend/app/(auth)/sign-up/page.tsx
+++ b/frontend/app/(auth)/sign-up/page.tsx
@@ -11,47 +11,7 @@ import { Select } from "@/components/ui/Select"
 import { RadioOption } from "@/components/ui/RadioOption"
 import { Textarea } from "@/components/ui/Textarea"
 import { Modal } from "@/components/ui/Modal"
-
-
-
-interface ProfileQuestionProps {
-  question: string
-  children: React.ReactNode
-  onSkip?: () => void
-  onNext?: () => void
-  isActive?: boolean
-}
-
-function ProfileQuestion({
-  question,
-  children,
-  onSkip = undefined,
-  onNext = undefined,
-  isActive = false
-}: ProfileQuestionProps) {
-  const showSkip = !!onSkip
-  const showNext = !!onNext
-  return (
-    <div style={{marginBottom: '20px'}}>
-      <p style={{ marginBottom: '5px', fontFamily: 'var(--font-sans)', fontSize: '18px', color: 'var(--color-text-primary)' }}>{question}</p>
-      {children}
-      {isActive && (showSkip || showNext) && (
-        <div style={{marginTop: '10px', justifyContent:'right', display: 'flex', gap: '5px'}}>
-          {showSkip && (<Button
-            type="button"
-            variant="secondary"
-            onClick={onSkip}
-          >Skip</Button>)}
-          {showNext && (<Button
-            type="button"
-            variant="primary"
-            onClick={onNext}
-          >Next</Button>)}
-        </div>
-      )}
-    </div>
-  )
-}
+import { useFormattedInputChange } from "@/lib/useFormattedInput"
 
 function setCookie() {
   document.cookie = "inSignUpFlow=true; path=/"
@@ -109,6 +69,13 @@ export default function SignUpPage() {
     symbol: boolean
     confirm: boolean
   }>({ length: false, upper: false, lower: false, number: false, symbol: false, confirm: false })
+
+  const handlePhoneChange = useFormattedInputChange(
+    phone,
+    setPhone,
+    formatPhone,
+    (v) => v.replace(/\D/g, '').slice(0, 10),
+  )
 
   const [showVerifyModal, setShowVerifyModal] = useState(false)
 
@@ -338,9 +305,8 @@ export default function SignUpPage() {
               type="tel"
               value={formatPhone(phone)}
               onChange={e => {
-                const raw = e.target.value.replace(/\D/g, '').slice(0, 10)
-                setPhone(raw);
-                setErrors(er => ({ ...er, phone: undefined }));
+                handlePhoneChange(e)
+                setErrors(er => ({ ...er, phone: undefined }))
               }}
               autoComplete="tel"
               error={errors.phone}

--- a/frontend/app/(auth)/sign-up/page.tsx
+++ b/frontend/app/(auth)/sign-up/page.tsx
@@ -1,17 +1,26 @@
 'use client'
 
 import { useEffect, useState } from "react"
-import { User, STUDENT_STATUS, authApi, ApiError, SHIRT_SIZE, usersApi } from "@/lib/api"
+import { 
+  authApi, ApiError, CanonicalEvent, canonicalEventsApi,
+  STUDENT_STATUS, SHIRT_SIZE, UserSlim, usersApi 
+} from "@/lib/api"
 import { useRouter } from "next/navigation"
 import { checkPassword, formatPhone, validateEmail, validatePassword, validatePhone } from "@/lib/auth"
 import { IconArrowLeft, IconCheckCircle, IconXCircle } from "@/components/ui/Icons"
 import { Input } from "@/components/ui/Input"
 import { Button } from "@/components/ui/Button"
 import { Select } from "@/components/ui/Select"
-import { RadioOption } from "@/components/ui/RadioOption"
+import { RadioGroup } from "@/components/ui/RadioGroup"
 import { Textarea } from "@/components/ui/Textarea"
 import { Modal } from "@/components/ui/Modal"
+import { 
+  CompetitionExperienceTable, CompetitionExperienceDraft, isCompetitionRowValid,
+  VolunteerExperienceTable, VolunteerExperienceDraft, isVolunteerRowValid
+} from "@/components/profile/ExperienceTables"
+import { ProfileQuestion } from "@/components/profile/ProfileQuestion"
 import { useFormattedInputChange } from "@/lib/useFormattedInput"
+
 
 function setCookie() {
   document.cookie = "inSignUpFlow=true; path=/"
@@ -52,7 +61,7 @@ export default function SignUpPage() {
   // 12  Complete button activated
   // ────────────────────────────────────────────────────────────────────────
   const [state, setState] = useState<number>(STATE.ACCOUNT)
-  const [user, setUser] = useState<User | null>(null)
+  const [user, setUser] = useState<UserSlim | null>(null)
   const [loading, setLoading] = useState(false)
 
 
@@ -88,14 +97,17 @@ export default function SignUpPage() {
 
     employer?: string
 
-    competition_exp?: string
-    volunteering_exp?: string
+    has_competition_experience?: boolean
+    has_volunteer_experience?: boolean
 
     shirt_size?: SHIRT_SIZE
     dietary_restriction?: string
   }>({})
-  const [competedBefore, setCompetedBefore] = useState<boolean | null>(null)
-  const [volunteeredBefore, setVolunteeredBefore] = useState<boolean | null> (null)
+  
+  const [events, setEvents] = useState<CanonicalEvent[]>([])
+  const [competitionRows, setCompetitionRows] = useState<CompetitionExperienceDraft[]>([])
+  const [volunteerRows, setVolunteerRows] = useState<VolunteerExperienceDraft[]>([])
+  
   const [hasDietary, setHasDietary] = useState<boolean | null>(null)
 
 
@@ -124,7 +136,7 @@ export default function SignUpPage() {
   const router = useRouter()
 
   useEffect(() => {
-    authApi.me().then(user => {
+    usersApi.me().then(user => {
       if (document.cookie.includes("inSignUpFlow")) {
         setUser(user)
         setState(STATE.STUDENT_STATUS)
@@ -132,6 +144,8 @@ export default function SignUpPage() {
         router.push('/dashboard')
       }
     }).catch(() => {})
+
+    canonicalEventsApi.list().then(setEvents).catch(() => {})
   }, [])
 
   async function handleRegisterSubmit(e: React.SyntheticEvent) {
@@ -199,7 +213,7 @@ export default function SignUpPage() {
     setLoading(true)
     setErrors({})
 
-    const cleaned = { ...profileData }
+    const cleaned: Record<string, unknown> = { ...profileData }
 
     if (cleaned.student_status === 'Undergraduate' || cleaned.student_status === 'Graduate') {
       cleaned.employer = undefined
@@ -209,23 +223,48 @@ export default function SignUpPage() {
       cleaned.student_status = cleaned.employer = cleaned.university = cleaned.major = cleaned.year_level = cleaned.graduation_year = undefined
     }
 
-    cleaned.competition_exp  = competedBefore === false ? "No competition experience."  : competedBefore === null  ? undefined : cleaned.competition_exp
-    cleaned.volunteering_exp = volunteeredBefore === false ? "No volunteer experience." : volunteeredBefore === null ? undefined : cleaned.volunteering_exp
-
     for (const key of Object.keys(cleaned)) {
-      if (cleaned[key as keyof typeof cleaned] === "") {
-        (cleaned as Record<string, unknown>)[key] = undefined
-      }
+      if (cleaned[key] === "") cleaned[key] = undefined
     }
 
-    if (cleaned.graduation_year && (cleaned.graduation_year < 1000 || cleaned.graduation_year > 9999)) {
-      setErrors(er => ({...er, graduation_year: "Must be a valid year."}))
+    if (cleaned.graduation_year && ((cleaned.graduation_year as number) < 1000 || (cleaned.graduation_year as number) > 9999)) {
+      setErrors(er => ({ ...er, graduation_year: "Must be a valid year." }))
       setLoading(false)
       return
     }
 
+    // TODO: decide partial-save recovery behavior — if updateMe() succeeds but a
+    // competition/volunteer experience POST fails mid-loop, flags are saved but
+    // rows may be incomplete. For now: surface the error, don't redirect.
     try {
       await usersApi.updateMe(cleaned)
+
+      if (profileData.has_competition_experience) {
+        await Promise.all(competitionRows.map(row =>
+          usersApi.addCompetitionExperience({
+            event_id: row.event_id as number,
+            school: row.school,
+            notes: row.notes || null,
+          })
+        ))
+      }
+
+      if (profileData.has_volunteer_experience) {
+        await Promise.all(volunteerRows.map(row =>
+          usersApi.addVolunteerExperience({
+            tournament_name: row.tournament_name,
+            year: Number(row.year),
+            role: row.role,
+            event_id: row.event_id ?? undefined,
+            notes: (row.event_id === null && row.event_name.trim()) || row.notes_other.trim()
+              ? {
+                  ...(row.event_id === null && row.event_name.trim() ? { event: row.event_name.trim() } : {}),
+                  ...(row.notes_other.trim() ? { other: row.notes_other.trim() } : {}),
+                }
+              : undefined,
+          })
+        ))
+      }
 
       clearCookie()
       router.push("/dashboard")
@@ -523,57 +562,49 @@ export default function SignUpPage() {
                   setState(STATE.COMPETED_BEFORE + 2)
                 }}
                 isActive={state === STATE.COMPETED_BEFORE}
-              ><div style={{ display: 'flex', gap: '8px' }}>
-                <RadioOption
+              >
+                <RadioGroup
                   name="competed"
-                  value="yes"
-                  checked={competedBefore === true}
-                  onChange={() => {
-                    setCompetedBefore(true)
+                  value={profileData.has_competition_experience === true ? "yes" : profileData.has_competition_experience === false ? "no" : null}
+                  onChange={v => {
+                    const val = v === "yes"
+                    setProfileData(d => ({ ...d, has_competition_experience: val }))
                     if (state >= STATE.COMPETED_BEFORE + 2) return
-                    setState(STATE.COMPETITION_EXP)
+                    setState(val ? STATE.COMPETITION_EXP : STATE.COMPETED_BEFORE + 2)
                   }}
-                  label="Yes"
+                  options={[
+                    { value: "yes", label: "Yes" },
+                    { value: "no", label: "No" },
+                  ]}
                   showCircle={false}
                   solid
                 />
-                <RadioOption
-                  name="competed"
-                  value="no"
-                  checked={competedBefore === false}
-                  onChange={() => {
-                    setCompetedBefore(false)
-                    if (state >= STATE.COMPETED_BEFORE + 2) return
-                    setState(STATE.COMPETED_BEFORE + 2)
-                  }}
-                  label="No"
-                  showCircle={false}
-                  solid
-                />
-              </div>
               </ProfileQuestion>
             )}
 
-            {state >= STATE.COMPETITION_EXP && competedBefore && (
+            {state >= STATE.COMPETITION_EXP && profileData.has_competition_experience && (
               <ProfileQuestion
-                question="List your competition experience."
+                question="Add your competition experience."
                 onSkip={() => {
-                  setCompetedBefore(null)
+                  setProfileData(d => ({ ...d, has_competition_experience: undefined }))
+                  setCompetitionRows([])
                   setState(STATE.VOLUNTEERED_BEFORE)
                 }}
                 onNext={() => {
-                  !profileData.competition_exp ? setErrors(er => ({...er, competition_exp: "Cannot be empty."}))
-                    : setState(STATE.VOLUNTEERED_BEFORE)
+                  if (competitionRows.length === 0 || !competitionRows.every(isCompetitionRowValid)) {
+                    setErrors(er => ({ ...er, competition_exp: "Each entry needs a school and a matched event." }))
+                    return
+                  }
+                  setState(STATE.VOLUNTEERED_BEFORE)
                 }}
                 isActive={state === STATE.COMPETITION_EXP}
-              ><Textarea
-                    value={profileData.competition_exp}
-                    onChange={e => {
-                      setProfileData(d => ({...d, competition_exp: e.target.value}))
-                      setErrors(er => ({...er, competition_exp: undefined}))
-                    }}
-                    error={errors.competition_exp}
-                />
+              >
+                <CompetitionExperienceTable value={competitionRows} onChange={setCompetitionRows} events={events} />
+                {errors.competition_exp && (
+                  <p style={{ fontFamily: 'var(--font-sans)', fontSize: '13px', color: 'var(--color-danger)', marginTop: '6px' }}>
+                    {errors.competition_exp}
+                  </p>
+                )}
               </ProfileQuestion>
             )}
 
@@ -584,57 +615,49 @@ export default function SignUpPage() {
                   setState(STATE.SHIRT_SIZE)
                 }}
                 isActive={state === STATE.VOLUNTEERED_BEFORE}
-              ><div style={{ display: 'flex', gap: '8px' }}>
-                <RadioOption
+              >
+                <RadioGroup
                   name="volunteered"
-                  value="yes"
-                  checked={volunteeredBefore === true}
-                  onChange={() => {
-                    setVolunteeredBefore(true)
+                  value={profileData.has_volunteer_experience === true ? "yes" : profileData.has_volunteer_experience === false ? "no" : null}
+                  onChange={v => {
+                    const val = v === "yes"
+                    setProfileData(d => ({ ...d, has_volunteer_experience: val }))
                     if (state >= STATE.SHIRT_SIZE) return
-                    setState(STATE.VOLUNTEERING_EXP)
+                    setState(val ? STATE.VOLUNTEERING_EXP : STATE.SHIRT_SIZE)
                   }}
-                  label="Yes"
+                  options={[
+                    { value: "yes", label: "Yes" },
+                    { value: "no", label: "No" },
+                  ]}
                   showCircle={false}
                   solid
                 />
-                <RadioOption
-                  name="volunteered"
-                  value="no"
-                  checked={volunteeredBefore === false}
-                  onChange={() => {
-                    setVolunteeredBefore(false)
-                    if (state >= STATE.SHIRT_SIZE) return
-                    setState(STATE.SHIRT_SIZE)
-                  }}
-                  label="No"
-                  showCircle={false}
-                  solid
-                />
-              </div>
               </ProfileQuestion>
             )}
 
-            {state >= STATE.VOLUNTEERING_EXP && volunteeredBefore && (
+            {state >= STATE.VOLUNTEERING_EXP && profileData.has_volunteer_experience && (
               <ProfileQuestion
-                question="List your volunteer experience."
+                question="Add your volunteer experience."
                 onSkip={() => {
-                  setVolunteeredBefore(null)
+                  setProfileData(d => ({ ...d, has_volunteer_experience: undefined }))
+                  setVolunteerRows([])
                   setState(STATE.SHIRT_SIZE)
                 }}
                 onNext={() => {
-                  !profileData.volunteering_exp ? setErrors(er => ({...er, volunteering_exp: "Cannot be empty."}))
-                    : setState(STATE.SHIRT_SIZE)
+                  if (volunteerRows.length === 0 || !volunteerRows.every(isVolunteerRowValid)) {
+                    setErrors(er => ({ ...er, volunteering_exp: "Each entry needs a tournament name, a 4-digit year, and a role." }))
+                    return
+                  }
+                  setState(STATE.SHIRT_SIZE)
                 }}
                 isActive={state === STATE.VOLUNTEERING_EXP}
-              ><Textarea
-                    value={profileData.volunteering_exp}
-                    onChange={e => {
-                      setProfileData(d => ({...d, volunteering_exp: e.target.value}))
-                      setErrors(er => ({...er, volunteering_exp: undefined}))
-                    }}
-                    error={errors.volunteering_exp}
-                />
+              >
+                <VolunteerExperienceTable value={volunteerRows} onChange={setVolunteerRows} events={events} />
+                {errors.volunteering_exp && (
+                  <p style={{ fontFamily: 'var(--font-sans)', fontSize: '13px', color: 'var(--color-danger)', marginTop: '6px' }}>
+                    {errors.volunteering_exp}
+                  </p>
+                )}
               </ProfileQuestion>
             )}
 
@@ -642,27 +665,22 @@ export default function SignUpPage() {
               <ProfileQuestion
                 question="What is your shirt size?"
                 onSkip={() => {
-                  setProfileData(d => ({...d, shirt_size: undefined}))
+                  setProfileData(d => ({ ...d, shirt_size: undefined }))
                   setState(STATE.DIETARY_RESTRICTIONS)
                 }}
                 isActive={state === STATE.SHIRT_SIZE}
-              ><div style={{ display: 'flex', gap: '8px' }}>
-                {["XS", "S", "M", "L", "XL", "XXL"].map(size => (
-                  <RadioOption
-                    name="shirt"
-                    value={size}
-                    key={size}
-                    checked={profileData.shirt_size === size}
-                    onChange={() => {
-                      setProfileData(d => ({...d, shirt_size: size as SHIRT_SIZE}))
-                      if (state === STATE.SHIRT_SIZE) setState(STATE.DIETARY_RESTRICTIONS)
-                    }}
-                    label={size}
-                    showCircle={false}
-                    solid
-                  />
-                ))}
-              </div>
+              >
+                <RadioGroup
+                  name="shirt"
+                  value={profileData.shirt_size ?? null}
+                  onChange={v => {
+                    setProfileData(d => ({ ...d, shirt_size: v as SHIRT_SIZE }))
+                    if (state === STATE.SHIRT_SIZE) setState(STATE.DIETARY_RESTRICTIONS)
+                  }}
+                  options={["XS", "S", "M", "L", "XL", "XXL"].map(size => ({ value: size, label: size }))}
+                  showCircle={false}
+                  solid
+                />
               </ProfileQuestion>
             )}
 
@@ -673,34 +691,23 @@ export default function SignUpPage() {
                   setState(STATE.COMPLETE)
                 }}
                 isActive={state === STATE.DIETARY_RESTRICTIONS}
-              ><div style={{ display: 'flex', gap: '8px' }}>
-                <RadioOption
+              >
+                <RadioGroup
                   name="dietary"
-                  value="yes"
-                  checked={hasDietary === true}
-                  onChange={() => {
-                    setHasDietary(true)
+                  value={hasDietary === true ? "yes" : hasDietary === false ? "no" : null}
+                  onChange={v => {
+                    const val = v === "yes"
+                    setHasDietary(val)
                     if (state >= STATE.COMPLETE) return
-                    setState(STATE.DIETARY_TEXT)
+                    setState(val ? STATE.DIETARY_TEXT : STATE.COMPLETE)
                   }}
-                  label="Yes"
+                  options={[
+                    { value: "yes", label: "Yes" },
+                    { value: "no", label: "No" },
+                  ]}
                   showCircle={false}
                   solid
                 />
-                <RadioOption
-                  name="dietary"
-                  value="no"
-                  checked={hasDietary === false}
-                  onChange={() => {
-                    setHasDietary(false)
-                    if (state >= STATE.COMPLETE) return
-                    setState(STATE.COMPLETE)
-                  }}
-                  label="No"
-                  showCircle={false}
-                  solid
-                />
-              </div>
               </ProfileQuestion>
             )}
 

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
-import { tournamentsApi, eventsApi, membershipsApi, Tournament, User, authApi, ApiError } from "@/lib/api"
+import { tournamentsApi, tournamentEventsApi, membershipsApi, Tournament, UserMeSlim, authApi, ApiError } from "@/lib/api"
 import { NewTournamentModal } from "@/components/ui/NewTournamentModal"
 import { Topbar } from "@/components/layout/Topbar"
 import { Banner, BannerProps } from "@/components/ui/Banner"
@@ -15,7 +15,7 @@ import { Tooltip, TooltipStatus } from "@/components/ui/Tooltip"
 
 interface BannerRule extends Omit<BannerProps, 'onDismiss'> {
   id: number
-  condition: (user: User) => boolean
+  condition: (user: UserMeSlim) => boolean
   snoozeDays: number
 }
 
@@ -141,11 +141,11 @@ export default function DashboardPage() {
       </Tooltip>
     },
     {id: 2, variant: "warning", message: "Your profile is incomplete",
-      condition: user => user.missing_profile_fields.length > 0, snoozeDays: 3,
+      condition: user => !user.is_profile_complete, snoozeDays: 3,
       action: <Button
         variant="secondary"
         size="sm"
-        onClick={() => router.push('/dashboard')} // temp for now, will push to profile later
+        onClick={() => router.push('/dashboard')} // TODO: push to /user/[id]/edit once that page exists
       >Complete Profile</Button>
     }
   ]
@@ -162,7 +162,7 @@ export default function DashboardPage() {
       setTournaments(data)
       data.forEach((t) => {
         Promise.all([
-          eventsApi.listByTournament(t.id).then((e) => e.length).catch(() => 0),
+          tournamentEventsApi.listByTournament(t.id).then((e) => e.length).catch(() => 0),
           membershipsApi.listByTournament(t.id).then((m) => m.length).catch(() => 0),
         ]).then(([events, volunteers]) => {
           setCounts((prev) => ({ ...prev, [t.id]: { events, volunteers } }))

--- a/frontend/components/profile/ExperienceTables.tsx
+++ b/frontend/components/profile/ExperienceTables.tsx
@@ -1,0 +1,118 @@
+// components/experience/ExperienceTables.tsx
+'use client'
+
+import { CanonicalEvent } from "@/lib/api"
+import { Input } from "@/components/ui/Input"
+import { Textarea } from "@/components/ui/Textarea"
+import { Button } from "@/components/ui/Button"
+import { Combobox } from "@/components/ui/Combobox"
+
+// -------------------------------------------------------------------------
+// Competition experience
+// -------------------------------------------------------------------------
+export interface CompetitionExperienceDraft {
+  school:     string
+  event_id:   number | null
+  event_name: string
+  notes:      string
+}
+
+export function isCompetitionRowValid(row: CompetitionExperienceDraft): boolean {
+  return !!row.school.trim() && row.event_id !== null
+}
+
+interface CompetitionExperienceTableProps {
+  value:  CompetitionExperienceDraft[]
+  onChange: (rows: CompetitionExperienceDraft[]) => void
+  events: CanonicalEvent[]
+}
+
+export function CompetitionExperienceTable({ value, onChange, events }: CompetitionExperienceTableProps) {
+  function addRow()    { onChange([...value, { school: '', event_id: null, event_name: '', notes: '' }]) }
+  function updateRow(i: number, patch: Partial<CompetitionExperienceDraft>) {
+    onChange(value.map((row, idx) => idx === i ? { ...row, ...patch } : row))
+  }
+  function removeRow(i: number) { onChange(value.filter((_, idx) => idx !== i)) }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+      {value.map((row, i) => (
+        <div key={i} style={{ border: '1px solid var(--color-border)', borderRadius: '8px', padding: '12px', display: 'flex', flexDirection: 'column', gap: '8px' }}>
+          <Input label="School" type="text" value={row.school} onChange={e => updateRow(i, { school: e.target.value })} fullWidth />
+          <Combobox
+            label="Event"
+            options={events}
+            getId={e => e.id}
+            getLabel={e => e.name}
+            value={row.event_name}
+            allowFreeText={false}
+            onChange={(text, matched) => updateRow(i, { event_name: text, event_id: matched ? matched.id : null })}
+          />
+          <Textarea label="Notes" value={row.notes} onChange={e => updateRow(i, { notes: e.target.value })} />
+          <Button type="button" variant="secondary" onClick={() => removeRow(i)}>Remove</Button>
+        </div>
+      ))}
+      <Button type="button" variant="secondary" onClick={addRow}>+ Add competition experience</Button>
+    </div>
+  )
+}
+
+// -------------------------------------------------------------------------
+// Volunteer experience
+// -------------------------------------------------------------------------
+export interface VolunteerExperienceDraft {
+  tournament_name: string
+  year:            string
+  event_id:        number | null
+  event_name:      string   // display text; also becomes notes.event if unmatched
+  role:            string
+  notes_other:     string
+}
+
+export function isVolunteerRowValid(row: VolunteerExperienceDraft): boolean {
+  return !!row.tournament_name.trim() && /^\d{4}$/.test(row.year) && !!row.role.trim()
+}
+
+interface VolunteerExperienceTableProps {
+  value:  VolunteerExperienceDraft[]
+  onChange: (rows: VolunteerExperienceDraft[]) => void
+  events: CanonicalEvent[]
+}
+
+export function VolunteerExperienceTable({ value, onChange, events }: VolunteerExperienceTableProps) {
+  function addRow()    { onChange([...value, { tournament_name: '', year: '', event_id: null, event_name: '', role: '', notes_other: '' }]) }
+  function updateRow(i: number, patch: Partial<VolunteerExperienceDraft>) {
+    onChange(value.map((row, idx) => idx === i ? { ...row, ...patch } : row))
+  }
+  function removeRow(i: number) { onChange(value.filter((_, idx) => idx !== i)) }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+      {value.map((row, i) => (
+        <div key={i} style={{ border: '1px solid var(--color-border)', borderRadius: '8px', padding: '12px', display: 'flex', flexDirection: 'column', gap: '8px' }}>
+          <Input label="Tournament Name" type="text" value={row.tournament_name} onChange={e => updateRow(i, { tournament_name: e.target.value })} fullWidth />
+          <Input
+            label="Year"
+            type="text"
+            value={row.year}
+            onChange={e => updateRow(i, { year: e.target.value.replace(/\D/g, '').slice(0, 4) })}
+            fullWidth
+          />
+          <Combobox
+            label="Event"
+            options={events}
+            getId={e => e.id}
+            getLabel={e => e.name}
+            value={row.event_name}
+            allowFreeText
+            onChange={(text, matched) => updateRow(i, { event_name: text, event_id: matched ? matched.id : null })}
+          />
+          <Input label="Role" type="text" value={row.role} onChange={e => updateRow(i, { role: e.target.value })} fullWidth />
+          <Textarea label="Notes" value={row.notes_other} onChange={e => updateRow(i, { notes_other: e.target.value })} />
+          <Button type="button" variant="secondary" onClick={() => removeRow(i)}>Remove</Button>
+        </div>
+      ))}
+      <Button type="button" variant="secondary" onClick={addRow}>+ Add volunteer experience</Button>
+    </div>
+  )
+}

--- a/frontend/components/profile/ProfileQuestion.tsx
+++ b/frontend/components/profile/ProfileQuestion.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { Button } from "@/components/ui/Button"
+
+interface ProfileQuestionProps {
+  question: string
+  children: React.ReactNode
+  onSkip?: () => void
+  onNext?: () => void
+  isActive?: boolean
+}
+
+export function ProfileQuestion({
+  question,
+  children,
+  onSkip = undefined,
+  onNext = undefined,
+  isActive = false
+}: ProfileQuestionProps) {
+  const showSkip = !!onSkip
+  const showNext = !!onNext
+  return (
+    <div style={{marginBottom: '20px'}}>
+      <p style={{ marginBottom: '5px', fontFamily: 'var(--font-sans)', fontSize: '18px', color: 'var(--color-text-primary)' }}>{question}</p>
+      {children}
+      {isActive && (showSkip || showNext) && (
+        <div style={{marginTop: '10px', justifyContent:'right', display: 'flex', gap: '5px'}}>
+          {showSkip && (<Button
+            type="button"
+            variant="secondary"
+            onClick={onSkip}
+          >Skip</Button>)}
+          {showNext && (<Button
+            type="button"
+            variant="primary"
+            onClick={onNext}
+          >Next</Button>)}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/components/ui/Combobox.tsx
+++ b/frontend/components/ui/Combobox.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { useState } from "react"
+import { Input } from "@/components/ui/Input"
+
+interface ComboboxProps<T> {
+  options:  T[]
+  getId:    (option: T) => string | number
+  getLabel: (option: T) => string
+
+  value:    string
+  onChange: (text: string, matched: T | null) => void
+
+  allowFreeText?: boolean
+  placeholder?:   string
+  label?:         string
+  maxResults?:    number
+}
+
+export function Combobox<T>({
+  options,
+  getId,
+  getLabel,
+  value,
+  onChange,
+  allowFreeText = true,
+  placeholder,
+  label,
+  maxResults = 8,
+}: ComboboxProps<T>) {
+  const [open, setOpen] = useState(false)
+  const [matched, setMatched] = useState<T | null>(null)
+
+  const query = value.trim().toLowerCase()
+  const matches = query
+    ? options.filter(o => getLabel(o).toLowerCase().includes(query)).slice(0, maxResults)
+    : []
+
+  function handleTextChange(text: string) {
+    setMatched(null)
+    onChange(text, null)
+    setOpen(true)
+  }
+
+  function handleSelect(option: T) {
+    const label = getLabel(option)
+    setMatched(option)
+    onChange(label, option)
+    setOpen(false)
+  }
+
+  const showHint = value.trim().length > 0 && matched === null
+
+  return (
+    <div style={{ position: 'relative' }}>
+      {label && (
+        <label style={{ fontFamily: 'var(--font-sans)', fontSize: '13px', color: 'var(--color-text-secondary)' }}>
+          {label}
+        </label>
+      )}
+      <Input
+        type="text"
+        value={value}
+        placeholder={placeholder ?? "Type to search..."}
+        onChange={e => handleTextChange(e.target.value)}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setTimeout(() => setOpen(false), 150)}
+        fullWidth
+      />
+      {open && matches.length > 0 && (
+        <div style={{
+          position: 'absolute', top: '100%', left: 0, right: 0, zIndex: 10,
+          background: 'var(--color-surface)', border: '1px solid var(--color-border)',
+          borderRadius: '6px', marginTop: '2px', maxHeight: '180px', overflowY: 'auto',
+        }}>
+          {matches.map(option => (
+            <div
+              key={getId(option)}
+              onMouseDown={() => handleSelect(option)}
+              style={{ padding: '8px 10px', cursor: 'pointer', fontFamily: 'var(--font-sans)', fontSize: '14px' }}
+            >
+              {getLabel(option)}
+            </div>
+          ))}
+        </div>
+      )}
+      {showHint && (
+        <p style={{ fontSize: '12px', color: allowFreeText ? 'var(--color-text-secondary)' : 'var(--color-danger)', marginTop: '2px' }}>
+          {allowFreeText ? "No matching option — will be saved as custom text." : "No matching option — select one from the list to continue."}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/components/ui/Combobox.tsx
+++ b/frontend/components/ui/Combobox.tsx
@@ -15,6 +15,8 @@ interface ComboboxProps<T> {
   placeholder?:   string
   label?:         string
   maxResults?:    number
+  /** External error, takes priority over the internal strict-mode "no match" hint. */
+  error?: string
 }
 
 const CUSTOM_THRESHOLD = 3
@@ -29,6 +31,7 @@ export function Combobox<T>({
   placeholder,
   label,
   maxResults = 8,
+  error,
 }: ComboboxProps<T>) {
   const [open, setOpen] = useState(false)
   const [matched, setMatched] = useState<T | null>(null)
@@ -60,6 +63,7 @@ export function Combobox<T>({
   }
 
   const showStrictHint = !open && !allowFreeText && value.trim().length > 0 && matched === null
+  const displayedError = error ?? (showStrictHint ? "No matching option — select one from the list to continue." : undefined)
 
   return (
     <div style={{ position: 'relative' }}>
@@ -71,7 +75,7 @@ export function Combobox<T>({
         onChange={e => handleTextChange(e.target.value)}
         onFocus={() => setOpen(true)}
         onBlur={() => setTimeout(() => setOpen(false), 150)}
-        error={showStrictHint ? "No matching option — select one from the list to continue." : undefined}
+        error={displayedError}
         fullWidth
       />
       {dropdownOpen && (

--- a/frontend/components/ui/Combobox.tsx
+++ b/frontend/components/ui/Combobox.tsx
@@ -17,6 +17,8 @@ interface ComboboxProps<T> {
   maxResults?:    number
 }
 
+const CUSTOM_THRESHOLD = 3
+
 export function Combobox<T>({
   options,
   getId,
@@ -36,6 +38,10 @@ export function Combobox<T>({
     ? options.filter(o => getLabel(o).toLowerCase().includes(query)).slice(0, maxResults)
     : []
 
+  const exactMatch = matches.some(o => getLabel(o).toLowerCase() === query)
+  const showCustomRow = allowFreeText && query.length > 0 && !exactMatch && matches.length < CUSTOM_THRESHOLD
+  const dropdownOpen = open && (matches.length > 0 || showCustomRow)
+
   function handleTextChange(text: string) {
     setMatched(null)
     onChange(text, null)
@@ -43,35 +49,40 @@ export function Combobox<T>({
   }
 
   function handleSelect(option: T) {
-    const label = getLabel(option)
+    const optLabel = getLabel(option)
     setMatched(option)
-    onChange(label, option)
+    onChange(optLabel, option)
     setOpen(false)
   }
 
-  const showHint = value.trim().length > 0 && matched === null
+  function handleSelectCustom() {
+    setOpen(false)
+  }
+
+  const showStrictHint = !open && !allowFreeText && value.trim().length > 0 && matched === null
 
   return (
     <div style={{ position: 'relative' }}>
-      {label && (
-        <label style={{ fontFamily: 'var(--font-sans)', fontSize: '13px', color: 'var(--color-text-secondary)' }}>
-          {label}
-        </label>
-      )}
       <Input
+        label={label}
         type="text"
         value={value}
         placeholder={placeholder ?? "Type to search..."}
         onChange={e => handleTextChange(e.target.value)}
         onFocus={() => setOpen(true)}
         onBlur={() => setTimeout(() => setOpen(false), 150)}
+        error={showStrictHint ? "No matching option — select one from the list to continue." : undefined}
         fullWidth
       />
-      {open && matches.length > 0 && (
+      {dropdownOpen && (
         <div style={{
           position: 'absolute', top: '100%', left: 0, right: 0, zIndex: 10,
-          background: 'var(--color-surface)', border: '1px solid var(--color-border)',
-          borderRadius: '6px', marginTop: '2px', maxHeight: '180px', overflowY: 'auto',
+          background: 'var(--color-surface)',
+          border: '1px solid var(--color-border)',
+          borderTop: 'none',
+          borderRadius: '0 0 6px 6px',
+          maxHeight: '180px', overflowY: 'auto',
+          boxShadow: 'var(--shadow-md, 0 4px 12px rgba(0,0,0,0.12))',
         }}>
           {matches.map(option => (
             <div
@@ -82,12 +93,20 @@ export function Combobox<T>({
               {getLabel(option)}
             </div>
           ))}
+          {showCustomRow && (
+            <div
+              onMouseDown={handleSelectCustom}
+              style={{
+                padding: '8px 10px', cursor: 'pointer',
+                fontFamily: 'var(--font-sans)', fontSize: '14px',
+                color: 'var(--color-text-secondary)',
+                borderTop: matches.length > 0 ? '1px solid var(--color-border)' : undefined,
+              }}
+            >
+              Use &ldquo;{value.trim()}&rdquo;
+            </div>
+          )}
         </div>
-      )}
-      {showHint && (
-        <p style={{ fontSize: '12px', color: allowFreeText ? 'var(--color-text-secondary)' : 'var(--color-danger)', marginTop: '2px' }}>
-          {allowFreeText ? "No matching option — will be saved as custom text." : "No matching option — select one from the list to continue."}
-        </p>
       )}
     </div>
   )

--- a/frontend/components/ui/RadioGroup.tsx
+++ b/frontend/components/ui/RadioGroup.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { RadioOption } from "@/components/ui/RadioOption"
+
+export interface RadioGroupOption {
+  value:       string
+  label:       string
+  description?: string
+}
+
+interface RadioGroupProps {
+  name:       string
+  value:      string | null
+  onChange:   (value: string) => void
+  options:    RadioGroupOption[]
+  mono?:      boolean
+  showCircle?: boolean
+  solid?:     boolean
+  direction?: 'row' | 'column'
+  gap?:       string
+}
+
+export function RadioGroup({
+  name,
+  value,
+  onChange,
+  options,
+  mono,
+  showCircle,
+  solid,
+  direction = 'row',
+  gap = '8px',
+}: RadioGroupProps) {
+  return (
+    <div style={{ display: 'flex', flexDirection: direction, gap }}>
+      {options.map(opt => (
+        <RadioOption
+          key={opt.value}
+          name={name}
+          value={opt.value}
+          checked={value === opt.value}
+          onChange={onChange}
+          label={opt.label}
+          description={opt.description}
+          mono={mono}
+          showCircle={showCircle}
+          solid={solid}
+        />
+      ))}
+    </div>
+  )
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -118,6 +118,9 @@ export interface AuthRegister {
 export const authApi = {
   login: (email: string, password: string) => api.post<User>('/auth/login/', { email, password }),
   logout: ()                               => api.post<void>('/auth/logout/', {}),
+  // TODO: /auth/me/ was removed from the backend — folded into GET /users/me/.
+  // Update this to call usersApi (or equivalent) and fix the callers in
+  // useAuth.tsx, sign-up/page.tsx, and verify-email/page.tsx.
   me: ()                                   => api.get<User>('/auth/me/'),
   register: (body: AuthRegister)           => api.post<User>('/auth/register/', body),
   verifyEmail: (token: string)             => api.get<void>(`/auth/verify-email/?token=${token}`),

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -65,18 +65,86 @@ export const api = {
 }
 
 // -------------------------------------------------------------------------
-// Auth
+// Canonical Events & Categories — global list, admin-managed
+// -------------------------------------------------------------------------
+export interface EventCategory {
+  id:   number
+  name: string
+}
+
+export interface CanonicalEvent {
+  id:          number
+  name:        string
+  category_id: number
+}
+
+export const eventCategoriesApi = {
+  list:   ()                                    => api.get<EventCategory[]>('/event-categories/'),
+  create: (body: { name: string })              => api.post<EventCategory>('/event-categories/', body),
+  update: (id: number, body: { name: string })  => api.patch<EventCategory>(`/event-categories/${id}/`, body),
+  delete: (id: number)                          => api.delete<void>(`/event-categories/${id}/`),
+}
+
+export const canonicalEventsApi = {
+  list:   ()                                              => api.get<CanonicalEvent[]>('/events/'),
+  create: (body: { name: string; category_id: number })   => api.post<CanonicalEvent>('/events/', body),
+  update: (id: number, body: Partial<{ name: string; category_id: number }>) =>
+    api.patch<CanonicalEvent>(`/events/${id}/`, body),
+  delete: (id: number)                                    => api.delete<void>(`/events/${id}/`),
+}
+
+// -------------------------------------------------------------------------
+// Auth / Users
 // -------------------------------------------------------------------------
 export type ROLE = "admin" | "user"
 export type STUDENT_STATUS = "Undergraduate" | "Graduate" | "Non-Student"
 export type SHIRT_SIZE = "XS" | "S" | "M" | "L" | "XL" | "XXL"
 
-interface UserBase {
-  email:               string
-  first_name:          string
-  last_name:           string
-  phone:               string | null
+export interface CompetitionExperience {
+  id:       number
+  event_id: number
+  school:   string
+  notes:    string | null
+}
 
+export interface VolunteerExperienceNotes {
+  event?: string
+  other?: string
+}
+
+export interface VolunteerExperience {
+  id:              number
+  tournament_name: string
+  year:            number
+  event_id:        number | null
+  role:            string
+  notes:           VolunteerExperienceNotes | null
+}
+
+// Matches UserSlimResponse — no student/employer/experience/shirt/dietary fields
+export interface UserSlim {
+  id:             number
+  first_name:     string
+  last_name:      string
+  email:          string
+  phone:          string | null
+  pronouns:       string | null
+
+  email_verified: boolean
+  role:           ROLE
+  is_active:      boolean
+
+  created_at:     string
+  updated_at:     string
+}
+
+// GET /users/me/ (default) — matches UserMeSlimResponse. No date_of_birth here.
+export interface UserMeSlim extends UserSlim {
+  is_profile_complete: boolean
+}
+
+// Matches UserFullResponse — adds the profile fields, no date_of_birth
+export interface UserFull extends UserSlim {
   student_status:      STUDENT_STATUS | null
   university:          string | null
   major:               string | null
@@ -85,28 +153,44 @@ interface UserBase {
 
   employer:            string | null
 
-  competition_exp:     string | null
-  volunteering_exp:    string | null
+  has_competition_experience: boolean | null
+  has_volunteer_experience:   boolean | null
 
-  shirt_size:          SHIRT_SIZE | null
-  dietary_restriction: string | null
+  competition_experience: CompetitionExperience[]
+  volunteer_experience:   VolunteerExperience[]
+
+  shirt_size:           SHIRT_SIZE | null
+  dietary_restriction:  string | null
 }
 
-export interface User extends UserBase {
-  id:                  number
-  
-  email_verified:      boolean
-  role:                ROLE
-  is_active:           boolean
-
-  created_at:          string
-  updated_at:          string
-
+// GET /users/me/?full=true — matches UserMeFullResponse
+export interface UserMeFull extends UserFull {
+  date_of_birth:          string | null
   missing_profile_fields: string[]
 }
 
-interface UserUpdate extends UserBase {}
+interface UserUpdate {
+  first_name?:          string
+  last_name?:           string
+  email?:                string
+  phone?:               string | null
+  date_of_birth?:       string | null
+  pronouns?:            string | null
+  student_status?:      STUDENT_STATUS | null
+  university?:          string | null
+  major?:               string | null
+  year_level?:          number | null
+  graduation_year?:     number | null
+  employer?:            string | null
+  has_competition_experience?: boolean | null
+  has_volunteer_experience?:   boolean | null
+  shirt_size?:          SHIRT_SIZE | null
+  dietary_restriction?: string | null
+}
 
+// -------------------------------------------------------------------------
+// Auth
+// -------------------------------------------------------------------------
 export interface AuthRegister {
   email:      string
   phone:      string
@@ -116,30 +200,66 @@ export interface AuthRegister {
 }
 
 export const authApi = {
-  login: (email: string, password: string) => api.post<User>('/auth/login/', { email, password }),
+  login: (email: string, password: string) => api.post<UserSlim>('/auth/login/', { email, password }),
   logout: ()                               => api.post<void>('/auth/logout/', {}),
-  // TODO: /auth/me/ was removed from the backend — folded into GET /users/me/.
-  // Update this to call usersApi (or equivalent) and fix the callers in
-  // useAuth.tsx, sign-up/page.tsx, and verify-email/page.tsx.
-  me: ()                                   => api.get<User>('/auth/me/'),
-  register: (body: AuthRegister)           => api.post<User>('/auth/register/', body),
+  register: (body: AuthRegister)           => api.post<UserSlim>('/auth/register/', body),
   verifyEmail: (token: string)             => api.get<void>(`/auth/verify-email/?token=${token}`),
   sendEmailVerification: ()                => api.post<void>('/auth/send-email-verification/', {}),
 }
-
 
 // -------------------------------------------------------------------------
 // Users
 // -------------------------------------------------------------------------
 export const usersApi = {
-  list:       ()                                       => api.get<User[]>('/users/'),
-  get:        (id: number)                             => api.get<User>(`/users/${id}/`),
-  getByEmail: (email: string)                          => api.get<User>(`/users/by-email/${encodeURIComponent(email)}/`),
-  update:     (id: number, body: Partial<UserUpdate>)  => api.patch<User>(`/users/${id}/`, body),
-  updateMe:   (body: Partial<UserUpdate>)              => api.patch<User>('/users/me/', body),
-  delete:     (id: number)                             => api.delete<void>(`/users/${id}/`),
+  // GET /users/me/ (default) — matches UserMeSlimResponse
+  me:       ()                          => api.get<UserMeSlim>('/users/me/'),
+  // GET /users/me/?full=true — matches UserMeFullResponse
+  meFull:   ()                          => api.get<UserMeFull>('/users/me/?full=true'),
+  // PATCH /users/me/ — matches UserMeFullResponse
+  updateMe: (body: Partial<UserUpdate>) => api.patch<UserMeFull>('/users/me/', body),
+
+  addCompetitionExperience: (body: { event_id: number; school: string; notes?: string | null }) =>
+    api.post<CompetitionExperience>('/users/me/competition-experience/', body),
+  updateCompetitionExperience: (id: number, body: Partial<{ event_id: number; school: string; notes: string | null }>) =>
+    api.patch<CompetitionExperience>(`/users/me/competition-experience/${id}/`, body),
+  deleteCompetitionExperience: (id: number) =>
+    api.delete<void>(`/users/me/competition-experience/${id}/`),
+
+  addVolunteerExperience: (body: {
+    tournament_name: string
+    year: number
+    role: string
+    event_id?: number | null
+    notes?: VolunteerExperienceNotes | null
+  }) => api.post<VolunteerExperience>('/users/me/volunteer-experience/', body),
+  updateVolunteerExperience: (id: number, body: Partial<{
+    tournament_name: string
+    year: number
+    role: string
+    event_id: number | null
+    notes: VolunteerExperienceNotes | null
+  }>) => api.patch<VolunteerExperience>(`/users/me/volunteer-experience/${id}/`, body),
+  deleteVolunteerExperience: (id: number) =>
+    api.delete<void>(`/users/me/volunteer-experience/${id}/`),
+
   getForTournament: (tournamentId: number, userId: number) =>
-    api.get<User>(`/tournaments/${tournamentId}/users/${userId}/`),
+    api.get<UserSlim>(`/tournaments/${tournamentId}/users/${userId}/`),
+}
+
+// -------------------------------------------------------------------------
+// Admin — Users
+// -------------------------------------------------------------------------
+interface AdminUserUpdate {
+  role?:      ROLE
+  is_active?: boolean
+}
+
+export const adminUsersApi = {
+  list:       ()                                   => api.get<UserSlim[]>('/admin/users/'),
+  get:        (id: number)                         => api.get<UserFull>(`/admin/users/${id}/`),
+  getByEmail: (email: string)                      => api.get<UserFull>(`/admin/users/by-email/${encodeURIComponent(email)}/`),
+  updateRole: (id: number, body: AdminUserUpdate)  => api.patch<UserSlim>(`/admin/users/${id}/`, body),
+  delete:     (id: number)                         => api.delete<void>(`/admin/users/${id}/`),
 }
 
 
@@ -195,9 +315,9 @@ export const tournamentsApi = {
 
 
 // -------------------------------------------------------------------------
-// Events — nested under /tournaments/{id}/events/
+// Tournament Events — nested under /tournaments/{id}/events/
 // -------------------------------------------------------------------------
-export interface Event {
+export interface TournamentEvent {
   id:                number
   tournament_id:     number
   name:              string
@@ -213,15 +333,15 @@ export interface Event {
   updated_at:        string
 }
 
-export const eventsApi = {
+export const tournamentEventsApi = {
   listByTournament: (tournamentId: number) =>
-    api.get<Event[]>(`/tournaments/${tournamentId}/events/`),
+    api.get<TournamentEvent[]>(`/tournaments/${tournamentId}/events/`),
   get:    (tournamentId: number, id: number) =>
-    api.get<Event>(`/tournaments/${tournamentId}/events/${id}/`),
-  create: (tournamentId: number, body: Partial<Event>) =>
-    api.post<Event>(`/tournaments/${tournamentId}/events/`, body),
-  update: (tournamentId: number, id: number, body: Partial<Event>) =>
-    api.patch<Event>(`/tournaments/${tournamentId}/events/${id}/`, body),
+    api.get<TournamentEvent>(`/tournaments/${tournamentId}/events/${id}/`),
+  create: (tournamentId: number, body: Partial<TournamentEvent>) =>
+    api.post<TournamentEvent>(`/tournaments/${tournamentId}/events/`, body),
+  update: (tournamentId: number, id: number, body: Partial<TournamentEvent>) =>
+    api.patch<TournamentEvent>(`/tournaments/${tournamentId}/events/${id}/`, body),
   delete: (tournamentId: number, id: number) =>
     api.delete<void>(`/tournaments/${tournamentId}/events/${id}/`),
 }

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -77,3 +77,14 @@ export function validatePassword(password: string): string | null {
 
     return null
 }
+
+export function validateDateOfBirth(value: string): string | null {
+  if (!value) return "Cannot be empty."
+
+  const date = new Date(value + "T00:00:00")
+  if (isNaN(date.getTime())) return "Must be a valid date."
+
+  if (date.getTime() > Date.now()) return "Cannot be in the future."
+
+  return null
+}

--- a/frontend/lib/useAuth.tsx
+++ b/frontend/lib/useAuth.tsx
@@ -1,13 +1,13 @@
 'use client'
 
 import { useState, useEffect, createContext, useContext, ReactNode } from 'react'
-import { authApi, User, ApiError } from '@/lib/api'
+import { authApi, usersApi, UserMeSlim, ApiError } from '@/lib/api'
 
 // -------------------------------------------------------------------------
 // Context
 // -------------------------------------------------------------------------
 interface AuthState {
-  user:    User | null
+  user:    UserMeSlim | null
   loading: boolean
   logout:  () => Promise<void>
 }
@@ -22,12 +22,12 @@ const AuthContext = createContext<AuthState>({
 // Provider — wrap the dashboard layout with this
 // -------------------------------------------------------------------------
 export function AuthProvider({ children }: { children: ReactNode }) {
-  const [user, setUser]       = useState<User | null>(null)
+  const [user, setUser]       = useState<UserMeSlim | null>(null)
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    // Calls GET /auth/me/ — returns current user or 401
-    authApi.me()
+    // Calls GET /users/me/ — returns current user or 401
+    usersApi.me()
       .then(setUser)
       .catch((err: unknown) => {
         if (err instanceof ApiError && err.status === 401) {

--- a/frontend/lib/useFormattedInput.ts
+++ b/frontend/lib/useFormattedInput.ts
@@ -1,0 +1,26 @@
+import { useCallback } from "react"
+
+/**
+ * Handles the classic controlled-input-with-formatting bug: when a format
+ * function inserts separator characters (spaces, parens, dashes), backspacing
+ * over a separator can strip to the same raw value as before, so React sees
+ * no change and the field appears stuck. This detects that case and manually
+ * drops the last raw character instead.
+ */
+export function useFormattedInputChange(
+  raw: string,
+  setRaw: (next: string) => void,
+  format: (raw: string) => string,
+  stripAndLimit: (input: string) => string = (v) => v.replace(/\D/g, ''),
+) {
+  return useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const inputVal = e.target.value
+    const newRaw = stripAndLimit(inputVal)
+
+    const nextRaw = newRaw === raw && inputVal.length < format(raw).length
+      ? raw.slice(0, -1)
+      : newRaw
+
+    setRaw(nextRaw)
+  }, [raw, setRaw, format, stripAndLimit])
+}


### PR DESCRIPTION
## Background

Free-text `competition_exp` and `volunteer_exp` columns on `User` can't be searched or filtered. TDs need to find volunteers by event experience. This replaces the blobs with structured entries that support filtering by event and expertise.

## Changes

### Canonical `Event` / `EventCategory` catalog

Note: this is a *different* concept from `TournamentEvent` (a per-tournament event instance with room/building/volunteers-needed, renamed from the old tournament-scoped `Event` in this same commit range). `Event`/`EventCategory` here is a global catalog used only for tagging user experience entries — don't confuse the two.

- `EventCategory`: `id`, `name` (unique)
- `Event`: `id`, `name` (unique), `category_id` FK to `EventCategory` (required)
- Admin-managed CRUD for both: `GET/POST/PATCH/DELETE /events/{event_id}/`, `GET/POST/PATCH/DELETE /event-categories/{category_id}/`
- `DELETE` is a hard delete on both, blocked with 409 if the row is still referenced (an event with experience entries, or a category with events)
- Canonical seed data loaded on startup (`app/db/seed_canon_events.py`, idempotent `INSERT ... ON CONFLICT DO NOTHING`)
- Routers registered, tests added (`test_events.py`)

### `UserCompetitionExperience` table

- Model: `id`, `user_id` FK, `event_id` FK, `school`, `notes`
- Self-service routes under `/users/me/competition-experience/`: `POST`, `PATCH /{id}/`, `DELETE /{id}/`
- Permission check restricts edits to the user's own entries (404 if not the owner)
- No list/filter endpoint yet — filtering by event is not implemented in this PR

### `UserVolunteerExperience` table

- Model: `id`, `user_id` FK, `tournament_name` (required), `year` (required), `event_id` FK (nullable — some roles are tournament-wide staff not tied to a specific event), `role` (bounded string), `notes` (JSON: `{event, other}`)
- Manual entry only — no link to `TournamentMembership`/`Tournament`; auto-populating entries from archived NEXUS tournaments is future work, not part of this PR
- Validator enforces exactly one of `event_id` or `notes.event` (a free-text event name) is set
- Self-service routes under `/users/me/volunteer-experience/`: `POST`, `PATCH /{id}/`, `DELETE /{id}/`, same 404-on-not-owner check as competition experience

### `User` model changes

- Added `has_competition_experience` and `has_volunteer_experience` (`Boolean, nullable=True`) — `null`=unanswered, `False`=explicitly none, `True`=claims entries exist
- Dropped `competition_exp` and `volunteering_exp` (Text columns) — confirmed no real data existed before dropping
- Profile-completeness logic split by response shape, computed via helper functions in `app/core/profile_status.py` (not a stored property):
  - `compute_missing_profile_fields(user)` → `list[str]`, used by `UserMeFullResponse.missing_profile_fields`
  - `is_profile_complete(user)` → `bool`, used by `UserMeSlimResponse.is_profile_complete`
  - Both apply the same three-state logic: `has_*_experience is None` → incomplete; `False` → skipped (explicitly none); `True` with no matching entries → still incomplete
- Migration covers all of the above

### Reads

- `GET /users/me/?full=true` returns `UserMeFullResponse` with nested `competition_experience`/`volunteer_experience`, eagerly loaded via `selectinload`
- `GET /admin/users/{user_id}/` (admin) returns the same nested lists via `UserFullResponse`, but lazy-loaded (not eager)
- **Breaking change**: `GET /auth/me/` was removed and folded into `GET /users/me/` to reduce ambiguity — any remaining callers need to migrate
- Bundled bugfix: `check_if_email_exists` now excludes the current user's own row, fixing a 409 that fired when a user PATCHed their profile without changing their email

### Also included — frontend wiring

This range also sweeps in frontend commits that support the tables above and were developed alongside them, not called out as separate tasks in the original issue:

- New `Combobox` and `RadioGroup` components (used for event/school selection on experience entries)
- Frontend API interfaces and `useAuth` updated to match the new `UserMeSlimResponse`/`UserMeFullResponse` split
- Birthdate and pronoun fields added to sign-up (unrelated to experience tables, but landed in this same commit stretch)
- Minor fixes: phone formatting on sign-up (backspace across separators), combobox error-display timing, dashboard API-shape updates, API router doc tags

### Also included — tournament membership age verification

This range also includes a related-but-separate feature that landed in the same commit stretch: age verification on `TournamentMembership`.

- `is_over_18` / `is_over_21` (hybrid properties, computed from birthdate) added to `TournamentMembership`, so TDs can age-verify registered volunteers
- `Membership` renamed to `TournamentMembership`; temporary profile fields that had been stored there removed (superseded by the `User`-level fields in this PR)
- Migration removing those temp tournament-membership profile fields

## Testing

- Full backend test suite, including new `test_events`, competition/volunteer experience route tests, and profile-completeness coverage for all three boolean states across both Slim and Full responses
- Manually verified `?full=true` returns nested experience lists correctly
- Manually verified the `event_id`/`notes.event` exactly-one-of validator
- Confirmed branch builds/runs in isolation

## Notes

- `event_id` on `UserVolunteerExperience` is nullable — some roles are tournament-wide staff not tied to a specific event
- Expertise and role fields were dropped from competition experience after design review — entries are event + school + notes only
- Age-verification changes to `TournamentMembership` (see above) are unrelated to this issue's scope but included in this PR for commit-grouping reasons
- Birthdate/pronoun sign-up fields and the combobox/radio-group components (see "Also included — frontend wiring" above) are likewise unrelated to this issue's scope but included for the same reason